### PR TITLE
Detect and translate invalid hrefs in 207 responses.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,12 +4,19 @@ Changes in release 0.31.0:
 * New interfaces and features:
  - add more gcc "nonnull" attributes to ne_request_* functions.
  - for OpenSSL builds, ne_md5 code uses the OpenSSL implementation
+ - add ne_path_escapef() function
+ - add NE_SESSFLAG_SHAREPOINT session flag which enables workarounds
+   for RFC non-compliance in Sharepoint (thanks to Jan-Marek Glogowski)
+ - ne_uri.h: add ne_path_escapef() in support of above
+ - ne_207.h: add ne_207_set_flags() likewise in support of above
 * Bug fixes:
  - fixes for OpenSSL 1.1.1 and TLSv1.3 support.
  - fix crash with GnuTLS in client cert support (Henrik Holst)
  - fix possible crash in ne_set_request_flag().
  - fix build with libxml2 2.9.10 and later
  - fix handling lock timeouts >LONG_MAX (Giuseppe Castagno)
+ - fix interop issue with SharePoint's malformed PROPFIND responses
+   (thanks to Jan-Marek Glogowski)
 
 Changes in release 0.30.2:
 * Add support for OpenSSL 1.1.x (Kurt Roeckx).

--- a/src/ne_207.h
+++ b/src/ne_207.h
@@ -71,6 +71,12 @@ typedef struct ne_207_parser_s ne_207_parser;
 ne_207_parser *ne_207_create(ne_xml_parser *parser, const ne_uri *base, 
                              void *userdata);
 
+/* Enable special href escaping hacks for Microsoft SharePoint. */
+#define NE_207_MSSP_ESCAPING (0x0001)
+
+/* Set given flags for the parser. */
+void ne_207_set_flags(ne_207_parser *p, unsigned int flags);
+
 /* Register response handling callbacks. */
 void ne_207_set_response_handlers(ne_207_parser *p,
                                   ne_207_start_response *start,

--- a/src/ne_props.c
+++ b/src/ne_props.c
@@ -605,6 +605,9 @@ ne_propfind_create(ne_session *sess, const char *uri, int depth)
     ne_207_set_propstat_handlers(ret->parser207, start_propstat,
 				  end_propstat);
 
+    if (ne_get_session_flag(sess, NE_SESSFLAG_SHAREPOINT))
+        ne_207_set_flags(ret->parser207, NE_207_MSSP_ESCAPING);
+
     /* The start of the request body is fixed: */
     ne_buffer_czappend(ret->body, 
                        "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" 

--- a/src/ne_session.h
+++ b/src/ne_session.h
@@ -100,6 +100,10 @@ typedef enum ne_session_flag_e {
     NE_SESSFLAG_EXPECT100, /* enable this flag to enable the flag
                             * NE_REQFLAG_EXPECT100 for new requests. */
 
+    NE_SESSFLAG_SHAREPOINT, /* this flag enables various workarounds
+                             * to improve interoperability with
+                             * SharePoint */
+
     NE_SESSFLAG_LAST /* enum sentinel value */
 } ne_session_flag;
 

--- a/src/ne_uri.c
+++ b/src/ne_uri.c
@@ -70,6 +70,7 @@
 
 #define URI_ALPHA (AL)
 #define URI_DIGIT (DG)
+#define URI_NONURI (OT)
 
 /* unreserved = ALPHA / DIGIT / "-" / "." / "_" / "~" */
 #define URI_UNRESERVED (AL | DG | DS | DT | US | TD)
@@ -476,16 +477,25 @@ char *ne_path_unescape(const char *uri)
 
 /* CH must be an unsigned char; evaluates to 1 if CH should be
  * percent-encoded (note !!x == x ? 1 : 0). */
-#define path_escape_ch(ch) (!!(uri_lookup(ch) & URI_ESCAPE))
+#define path_escape_ch(ch, mask) (!!(uri_lookup(ch) & (mask)))
 
-char *ne_path_escape(const char *path) 
+char *ne_path_escape(const char *path)
+{
+    return ne_path_escapef(path, NE_PATH_NONRES);
+}
+
+char *ne_path_escapef(const char *path, unsigned int flags)
 {
     const unsigned char *pnt;
     char *ret, *p;
     size_t count = 0;
+    unsigned short mask = 0;
+
+    if (flags & NE_PATH_NONRES) mask |= URI_ESCAPE;
+    if (flags & NE_PATH_NONURI) mask |= URI_NONURI;
 
     for (pnt = (const unsigned char *)path; *pnt != '\0'; pnt++) {
-        count += path_escape_ch(*pnt);
+        count += path_escape_ch(*pnt, mask);
     }
 
     if (count == 0) {
@@ -494,7 +504,7 @@ char *ne_path_escape(const char *path)
 
     p = ret = ne_malloc(strlen(path) + 2 * count + 1);
     for (pnt = (const unsigned char *)path; *pnt != '\0'; pnt++) {
-	if (path_escape_ch(*pnt)) {
+	if (path_escape_ch(*pnt, mask)) {
 	    /* Escape it - %<hex><hex> */
 	    sprintf(p, "%%%02x", (unsigned char) *pnt);
 	    p += 3;

--- a/src/ne_uri.h
+++ b/src/ne_uri.h
@@ -32,6 +32,18 @@ NE_BEGIN_DECLS
  * string and never NULL. */
 char *ne_path_escape(const char *path);
 
+ /* NE_PATH_NONRES - anything other than "unreserved" and the
+  * forward-slash character percent-encoded according to the URI
+  * encoding rules; same rules as ne_path_escape(). */
+#define NE_PATH_NONRES (0x0001)
+/* Escape any characters outside of those allowed in URIs. */
+#define NE_PATH_NONURI (0x0002)
+
+/* Return a copy of a path string with escaping applied per rules
+ * determined by any combination of NE_PATH_* flags given.  Returns a
+ * malloc-allocated string and never NULL. */
+char *ne_path_escapef(const char *path, unsigned int flags);
+
 /* Return a decoded copy of a percent-encoded path string. Returns
  * malloc-allocated path on success, or NULL if the string contained
  * any syntactically invalid percent-encoding sequences. */

--- a/src/neon.vers
+++ b/src/neon.vers
@@ -20,3 +20,8 @@ NEON_0_30 {
     ne_ssl_context_get_flag;
     ne_set_addrlist2;
 };
+
+NEON_0_31 {
+    ne_path_escapef;
+    ne_207_set_flags;
+};


### PR DESCRIPTION
* src/ne_207.c (xlate_invalid_href): New function.
  (end_element): Use it here if URI parsing fails; add debugging.

* test/props.c (propfind): Add test cases.