### PR TITLE
0.31 fixes

### DIFF
--- a/src/ne_openssl.c
+++ b/src/ne_openssl.c
@@ -1328,6 +1328,19 @@ void ne_md5_process_bytes(const void *buffer, size_t len,
     EVP_DigestUpdate(ctx->ctx, buffer, len);
 }
 
+void *ne_md5_read_ctx(const struct ne_md5_ctx *ctx, void *resbuf)
+{
+    EVP_MD_CTX *ssl_ctx = EVP_MD_CTX_new();
+
+    if (ssl_ctx) {
+        if (EVP_MD_CTX_copy(ssl_ctx, ctx->ctx))
+            EVP_DigestFinal(ssl_ctx, resbuf, NULL);
+        EVP_MD_CTX_free(ssl_ctx);
+    }
+
+    return resbuf;
+}
+
 void *ne_md5_finish_ctx(struct ne_md5_ctx *ctx, void *resbuf)
 {
     EVP_DigestFinal(ctx->ctx, resbuf, NULL);

--- a/src/ne_string.c
+++ b/src/ne_string.c
@@ -572,7 +572,7 @@ static const unsigned char ascii_tolower[256] = {
 
 #define TOLOWER(ch) ascii_tolower[ch]
 
-const unsigned char *const ne_tolower_array(void)
+const unsigned char *ne_tolower_array(void)
 {
     return ascii_tolower;
 }

--- a/src/ne_string.h
+++ b/src/ne_string.h
@@ -173,7 +173,7 @@ int ne_strncasecmp(const char *s1, const char *s2, size_t n);
  * char. */
 #define ne_tolower(c) (ne_tolower_array()[(unsigned char)c])
 
-const unsigned char *const ne_tolower_array(void);
+const unsigned char *ne_tolower_array(void);
 
 /* Convert an ASCII hexadecimal character in the ranges '0'..'9'
  * 'a'..'f' 'A'..'F' to its numeric equivalent. */


### PR DESCRIPTION
I tried to build LibreOffice with the new release 0.31.0. Upstream patch is https://gerrit.libreoffice.org/c/core/+/91070.

I could get rid of a few LO neon patches, but also had to add two new ones:

1. gcc from Ubuntu 18.04 generates warnings for commit 13c4d5f ("* src/ne_string.h, src/ne_string.c (ne_tolower_array): Mark as const the returned pointer."). That's just annoying and can be reverted easily. Is gcc wrong?

2. LO builds neon using it's own infrastructure and also provides it's own linker script on Windows (external/neon/neon.def), which resulted in:

[build LNK] Library/neon.dll
neon.def : error LNK2001: unresolved external symbol ne_md5_read_ctx
C:/cygwin/home/tdf/lode/jenkins/workspace/gerrit_windows/workdir/LinkTarget/Library/ineon.lib : fatal error LNK1120: 1 unresolved externals
make[1]: *** [C:/cygwin/home/tdf/lode/jenkins/workspace/gerrit_windows/external/neon/Library_neon.mk:10: C:/cygwin/home/tdf/lode/jenkins/workspace/gerrit_windows/instdir/program/neon.dll] Error 42

ne_md5_read_ctx is missing when building with OpenSSL and this breaks the ABI and API.

I tried to implement ne_md5_read_ctx with OpenSSL calls.