### PR TITLE
Prevent gcc warning compiling 0.31.0

### DIFF
--- a/src/ne_string.c
+++ b/src/ne_string.c
@@ -572,7 +572,7 @@ static const unsigned char ascii_tolower[256] = {
 
 #define TOLOWER(ch) ascii_tolower[ch]
 
-const unsigned char *const ne_tolower_array(void)
+const unsigned char *ne_tolower_array(void)
 {
     return ascii_tolower;
 }

--- a/src/ne_string.h
+++ b/src/ne_string.h
@@ -173,7 +173,7 @@ int ne_strncasecmp(const char *s1, const char *s2, size_t n);
  * char. */
 #define ne_tolower(c) (ne_tolower_array()[(unsigned char)c])
 
-const unsigned char *const ne_tolower_array(void);
+const unsigned char *ne_tolower_array(void);
 
 /* Convert an ASCII hexadecimal character in the ranges '0'..'9'
  * 'a'..'f' 'A'..'F' to its numeric equivalent. */


### PR DESCRIPTION
gcc from Ubuntu 18.04 generates warnings for commit 13c4d5f ("* src/ne_string.h, src/ne_string.c (ne_tolower_array): Mark as const the returned pointer."). That's just annoying and can be reverted easily. Is gcc wrong?