### PR TITLE
Fix LibreSSL support

### DIFF
--- a/src/ne_openssl.c
+++ b/src/ne_openssl.c
@@ -578,7 +578,7 @@ ne_ssl_context *ne_ssl_context_create(int mode)
         /* enable workarounds for buggy SSL server implementations */
         SSL_CTX_set_options(ctx->ctx, SSL_OP_ALL);
         SSL_CTX_set_verify(ctx->ctx, SSL_VERIFY_PEER, verify_callback);
-#if OPENSSL_VERSION_NUMBER >= 0x10101000L
+#if !defined(LIBRESSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x10101000L
         SSL_CTX_set_post_handshake_auth(ctx->ctx, 1);
 #endif
     } else if (mode == NE_SSL_CTX_SERVER) {

--- a/src/ne_socket.c
+++ b/src/ne_socket.c
@@ -610,7 +610,7 @@ static int error_ossl(ne_socket *sock, int sret);
 /* OpenSSL I/O function implementations. */
 static int readable_ossl(ne_socket *sock, int secs)
 {
-#if OPENSSL_VERSION_NUMBER < 0x10101000L
+#if defined(LIBRESSL_VERSION_NUMBER) || OPENSSL_VERSION_NUMBER < 0x10101000L
     /* Sufficient for TLSv1.2 and earlier. */
     if (SSL_pending(sock->ssl))
 	return 0;


### PR DESCRIPTION
These two commits fix neon-0.31.0 with LibreSSL.

Fixed in voidlinux with this commit: https://github.com/void-linux/void-packages/commit/d8656b4850ac9fda9460207bfbca3b1b3342c1e8

Cheers.