### PR TITLE
cppcheck issues

### DIFF
--- a/src/ne_auth.c
+++ b/src/ne_auth.c
@@ -1618,7 +1618,7 @@ static void auth_register(ne_session *sess, int isproxy, unsigned protomask,
         protomask |= NE_AUTH_GSSAPI_ONLY | NE_AUTH_SSPI;
     }
 
-    if (protomask | NE_AUTH_DIGEST) {
+    if ((protomask & NE_AUTH_DIGEST) == NE_AUTH_DIGEST) {
         struct ne_md5_ctx *ctx = ne_md5_create_ctx();
 
         if (ctx) {

--- a/src/ne_props.c
+++ b/src/ne_props.c
@@ -93,10 +93,10 @@ struct ne_prop_result_set_s {
 #define MAX_PROP_COUNTER (1024)
 
 static int 
-startelm(void *userdata, int state, const char *name, const char *nspace,
+startelm(void *userdata, int state, const char *nspace, const char *name,
 	 const char **atts);
 static int 
-endelm(void *userdata, int state, const char *name, const char *nspace);
+endelm(void *userdata, int state, const char *nspace, const char *name);
 
 /* Handle character data; flat property value. */
 static int chardata(void *userdata, int state, const char *data, size_t len)


### PR DESCRIPTION
- Fix: digest authentication #19 
   neon/src/ne_auth.c:1621:19: warning: Result of operator '|' is always true if one operand is non-zero. Did you intend to use '&'? [badBitmaskCheck]
       if (protomask | NE_AUTH_DIGEST)  
                     ^
- Fix: argument order
   neon/src/ne_props.c:386:27: warning: Function 'startelm' argument order different: declaration 'userdata, state, name, nspace, atts' definition 'userdata, parent, nspace, name, atts' [funcArgOrderDifferent]
   static int startelm(void *userdata, int parent,
                             ^
   neon/src/ne_props.c:477:25: warning: Function 'endelm' argument order different: declaration 'userdata, state, name, nspace' definition 'userdata, state, nspace, name' [funcArgOrderDifferent]
   static int endelm(void *userdata, int state,
                           ^