### PR TITLE
Handle Digest challenges in algorithm strength order (issue #26):

### DIFF
--- a/test/auth.c
+++ b/test/auth.c
@@ -1297,6 +1297,7 @@ static int multi_rfc7616(void)
 
     ne_session_destroy(sess);
     ne_buffer_destroy(buf);
+    ne_buffer_destroy(exp);
 
     return await_server();
 }


### PR DESCRIPTION
```
Handle Digest challenges in algorithm strength order (closes #26):

* src/ne_auth.c (insert_challenge): Take the challenge as an argument
  and adjust to sort by Digest algorithm as well as challenge
  strength.
  (auth_challenge): Adjust to allocate challenge first, and insert later
  as above.

* test/auth.c (init): New function.
  (multi_rfc7616): New test case.
```