### PR TITLE
Makefile: Fix doc issue in out of source builds

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -77,7 +77,7 @@ cover: subdirs
 	@cd test && $(MAKE) check
 	@cd src && $(GCOV) -cb $(MODULE)
 
-# as per 'cover' target; prints list of functions without 100% coverage 
+# as per 'cover' target; prints list of functions without 100% coverage
 uncover: subdirs
 	@rm -f src/*.*da test/common/*.*da test/*.*da
 	@cd test && $(MAKE) check
@@ -93,23 +93,23 @@ subdirs:
 docs: docs-man docs-html
 
 docs-man:
-	rm -rf doc/man; mkdir doc/man
-	$(XMLTO) -o `pwd`/doc/man -x doc/man.xsl man doc/manual.xml
+	rm -rf doc/man; mkdir -p doc/man
+	$(XMLTO) -o `pwd`/doc/man -x $(srcdir)/doc/man.xsl man $(srcdir)/doc/manual.xml
 
 docs-pdf:
-	$(XMLTO) -o `pwd`/doc pdf doc/manual.xml
+	$(XMLTO) -o `pwd`/doc pdf $(srcdir)/doc/manual.xml
 
 docs-ps:
-	$(XMLTO) -o `pwd`/doc ps doc/manual.xml
+	$(XMLTO) -o `pwd`/doc ps $(srcdir)/doc/manual.xml
 
 docs-html:
 	test -d doc/html && rm -rf doc/html || true
-	mkdir doc/html
-	$(XMLTO) -o `pwd`/doc/html -x doc/html.xsl html doc/manual.xml
+	mkdir -p doc/html
+	$(XMLTO) -o `pwd`/doc/html -x $(srcdir)/doc/html.xsl html $(srcdir)/doc/manual.xml
 
 # Validate the manual source
 docs-valid:
-	xmllint --noout --valid doc/manual.xml
+	xmllint --noout --valid $(srcdir)/doc/manual.xml
 
 clean:
 	@cd src && $(MAKE) clean
@@ -128,18 +128,18 @@ neon-config: $(srcdir)/neon-config.in
 
 install-docs: install-man install-html
 
-install-html:
+install-html: docs-html
 	$(INSTALL) -d $(DESTDIR)$(docdir)/html
-	for d in $(srcdir)/doc/html/*.html; do \
+	for d in doc/html/*.html; do \
 		$(INSTALL_DATA) $$d $(DESTDIR)$(docdir)/html; \
 	done
 
-install-man:
+install-man: docs-man
 	$(INSTALL) -d $(DESTDIR)$(man3dir)
 	$(INSTALL) -d $(DESTDIR)$(man1dir)
-	for m in $(srcdir)/doc/man/*.3; do \
+	for m in doc/man/*.3; do \
 	 $(INSTALL_DATA) $$m $(DESTDIR)$(man3dir); done
-	for m in $(srcdir)/doc/man/*.1; do \
+	for m in doc/man/*.1; do \
 	 $(INSTALL_DATA) $$m $(DESTDIR)$(man1dir); done
 
 install: install-@ALLOW_INSTALL@
@@ -218,4 +218,3 @@ doc-status:
 	@for f in `nm src/.libs/libneon.so | grep ' T ' | colrm 1 11`; do \
 	   test -f doc/man/$$f.3 || echo -n " $$f"; \
 	done; echo
-


### PR DESCRIPTION
This should fix issues where the configuring is done outside of the neon root dir