### PR TITLE
Add new auth credentials callback which unifies server/proxy auth

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,18 +4,19 @@ Changes in release 0.32.0:
  - NE_AUTH_DIGEST now only enables RFC 2617/7616 auth by default;
    to enable weaker RFC 2069 Digest, use NE_AUTH_LEGACY_DIGEST
    (this is a security enhancement, not an API/ABI break)
-* API clarification:
- - for ne_auth.h, the character encoding of the username provided
-   by a credentials callback was unspecified.  Callers providing
-   non-alphanumeric usernames for Basic and Digest challenges must
-   now use the NE_AUTH_UTF8 flag, or the auth challenge will fail
-   if the username cannot be sent safely.
+* Interface clarifications:
+ - ne_auth.h: use of non-ASCII usernames with the ne_auth_creds
+   callback type is now rejected for Digest auth since the
+   encoding is not known.  ne_add_auth() can be used instead.
 * New interfaces and features:
- - ne_string.h: added ne_strhash, ne_vstrhash, ne_strparam
+ - ne_string.h: added ne_strhash(), ne_vstrhash(), ne_strparam()
  - ne_auth.h: added RFC 7616 (Digest authentication) support,
    including userhash=, username*= and SHA-2-256/512-256 algorithms
    (SHA-2 requires GnuTLS/OpenSSL).  added NE_AUTH_WEAK_DIGEST
    to re-enable RFC 2069 Digest support
+ - ne_auth.h: added ne_add_auth() unified auth callback interface,
+   accepts (only) UTF-8 usernames, uses a larger password buffer,
+   and has different/improved attempt counter semantics.
 
 Changes in release 0.31.0:
 * Interface changes:

--- a/test/utils.c
+++ b/test/utils.c
@@ -34,7 +34,7 @@
 #include "tests.h"
 #include "utils.h"
 
-static int serve_response(ne_socket *s, const char *response)
+int serve_response(ne_socket *s, const char *response)
 {
     CALL(discard_request(s));
     CALL(discard_body(s));

--- a/test/utils.h
+++ b/test/utils.h
@@ -29,6 +29,8 @@
 
 int single_serve_string(ne_socket *s, void *userdata);
 
+int serve_response(ne_socket *s, const char *response);
+
 struct many_serve_args {
     int count;
     const char *str;


### PR DESCRIPTION
Add new auth credentials callback which unifies server/proxy auth
takes only UTF-8 usernames, takes a larger password buffer, and
has improved semantics for the attempt counter.
```
* src/ne_auth.h: Drop NE_AUTH_UTF8, add NE_AUTH_PROXY.
  Add ne_add_auth, ne_auth_provide type.

* src/ne_auth.c (struct auth_handler): Add new_creds field.
  (ABUFSIZE): Define constant.
  (auth_session): Use ABUFSIZE for username buffer.
  (get_credentials): Invoke new_creds callback if available,
  using passed-in attempt counter.
  (basic_challenge): Use ABUFSIZE for password buffer.
  (digest_challenge): Reject non-ASCII usernames if new_creds
  callback is not used.
  (auth_register): Take new_creds callback.
  (ne_set_server_auth, ne_set_proxy_auth,
   ne_add_server_auth, ne_add_proxy_auth): Adjust for above.
  (ne_add_auth): New function.

* test/auth.c (multi_provider_cb, serve_provider, multi_provider):
  New test case.
```