### PR TITLE
WIP: Add ne_ssl_cert_hdigest, alternative to ne_ssl_cert_digest.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -17,6 +17,7 @@ Changes in release 0.32.0:
    accepts (only) UTF-8 usernames, uses a larger password buffer,
    and has different/improved attempt counter semantics.
  - RFC 7617 scoping rules are now applied for Basic authentication.
+ - ne_ssl.h: add ne_ssl_cert_hdigest()
 
 Changes in release 0.31.2:
 * Fix ne_md5_read_ctx() with OpenSSL on big-endian architectures.

--- a/src/ne_ssl.h
+++ b/src/ne_ssl.h
@@ -93,6 +93,12 @@ const ne_ssl_dname *ne_ssl_cert_subject(const ne_ssl_certificate *cert);
  * NE_SSL_DIGESTLEN bytes in length. */
 int ne_ssl_cert_digest(const ne_ssl_certificate *cert, char *digest);
 
+/* Calculate the certificate digest ("fingerprint") and format it as a
+ * NUL-terminated hex string using the hash algorithm and formatting
+ * flags exactly as if flags was passed to ne_strhash().  Returns NULL
+ * on error. */
+char *ne_ssl_cert_hdigest(const ne_ssl_certificate *cert, unsigned int flags);
+
 /* Copy the validity times for the certificate 'cert' into 'from' and
  * 'until' (either may be NULL).  If the time cannot be represented by
  * a time_t value, then (time_t)-1 will be written. */

--- a/src/ne_stubssl.c
+++ b/src/ne_stubssl.c
@@ -107,6 +107,11 @@ int ne_ssl_cert_digest(const ne_ssl_certificate *cert, char digest[60])
     return -1;
 }
 
+char *ne_ssl_cert_hdigest(const ne_ssl_certificate *cert, unsigned int flags)
+{
+    return NULL;
+}
+
 void ne_ssl_cert_validity_time(const ne_ssl_certificate *cert,
                                time_t *from, time_t *until) {}
 

--- a/src/neon.vers
+++ b/src/neon.vers
@@ -31,4 +31,5 @@ NEON_0_32 {
     ne_vstrhash;
     ne_strparam;
     ne_add_auth;
+    ne_ssl_cert_hdigest;
 };

--- a/test/stubs.c
+++ b/test/stubs.c
@@ -123,6 +123,7 @@ static int stub_ssl(void)
                              ne_ssl_cert_issuer(cert)));
         ONN("this code shouldn't run", ne_ssl_cert_identity(issuer) != NULL);
         ONN("this code shouldn't run", ne_ssl_cert_export(cert) != NULL);
+        ONN("this code shouldn't run", ne_ssl_cert_hdigest(cert, NE_HASH_MD5) != NULL);
     }
 
     ONN("this code shouldn't run", ne_ssl_cert_import("foo") != NULL);


### PR DESCRIPTION
* src/ne_openssl.c (ne_ssl_cert_hdigest): New function.
  (hash_to_md): Factor out of ne_vstrhash.
  (ne_vstrhash): Use it.

* test/ssl.c (cert_hdigests): New test.