### PR TITLE
Various minor Coverity/clang warning fixes, no functional change:

### DIFF
--- a/src/ne_dates.c
+++ b/src/ne_dates.c
@@ -124,34 +124,33 @@ time_t ne_iso8601_parse(const char *date)
     int off_hour, off_min;
     double sec;
     off_t fix;
-    int n;
     time_t result;
 
     /*  it goes: ISO8601: 2001-01-01T12:30:00+03:30 */
-    if ((n = sscanf(date, ISO8601_FORMAT_P,
-		    &gmt.tm_year, &gmt.tm_mon, &gmt.tm_mday,
-		    &gmt.tm_hour, &gmt.tm_min, &sec,
-		    &off_hour, &off_min)) == 8) {
-      gmt.tm_sec = (int)sec;
-      fix = - off_hour * 3600 - off_min * 60;
+    if (sscanf(date, ISO8601_FORMAT_P,
+               &gmt.tm_year, &gmt.tm_mon, &gmt.tm_mday,
+               &gmt.tm_hour, &gmt.tm_min, &sec,
+               &off_hour, &off_min) == 8) {
+        gmt.tm_sec = (int)sec;
+        fix = - off_hour * 3600 - off_min * 60;
     }
     /*  it goes: ISO8601: 2001-01-01T12:30:00-03:30 */
-    else if ((n = sscanf(date, ISO8601_FORMAT_M,
-			 &gmt.tm_year, &gmt.tm_mon, &gmt.tm_mday,
-			 &gmt.tm_hour, &gmt.tm_min, &sec,
-			 &off_hour, &off_min)) == 8) {
-      gmt.tm_sec = (int)sec;
-      fix = off_hour * 3600 + off_min * 60;
+    else if (sscanf(date, ISO8601_FORMAT_M,
+                    &gmt.tm_year, &gmt.tm_mon, &gmt.tm_mday,
+                    &gmt.tm_hour, &gmt.tm_min, &sec,
+                    &off_hour, &off_min) == 8) {
+        gmt.tm_sec = (int)sec;
+        fix = off_hour * 3600 + off_min * 60;
     }
     /*  it goes: ISO8601: 2001-01-01T12:30:00Z */
-    else if ((n = sscanf(date, ISO8601_FORMAT_Z,
-			 &gmt.tm_year, &gmt.tm_mon, &gmt.tm_mday,
-			 &gmt.tm_hour, &gmt.tm_min, &sec)) == 6) {
-      gmt.tm_sec = (int)sec;
-      fix = 0;
+    else if (sscanf(date, ISO8601_FORMAT_Z,
+                    &gmt.tm_year, &gmt.tm_mon, &gmt.tm_mday,
+                    &gmt.tm_hour, &gmt.tm_min, &sec) == 6) {
+        gmt.tm_sec = (int)sec;
+        fix = 0;
     }
     else {
-      return (time_t)-1;
+        return (time_t)-1;
     }
 
     gmt.tm_year -= 1900;

--- a/src/ne_string.c
+++ b/src/ne_string.c
@@ -344,7 +344,7 @@ void ne_buffer_qappend(ne_buffer *buf, const unsigned char *data, size_t len)
 char *ne_strnqdup(const unsigned char *data, size_t len)
 {
     const unsigned char *dend = data + len;
-    char *dest = malloc(qappend_count(data, dend) + 1);
+    char *dest = ne_malloc(qappend_count(data, dend) + 1);
 
     quoted_append(dest, data, dend);
 

--- a/src/ne_xml.c
+++ b/src/ne_xml.c
@@ -471,7 +471,7 @@ ne_xml_parser *ne_xml_create(void)
     p->current = p->root = ne_calloc(sizeof *p->root);
     p->root->default_ns = "";
     p->root->state = 0;
-    strcpy(p->error, _("Unknown error"));
+    ne_strnzcpy(p->error, _("Unknown error"), sizeof p->error);
 #ifdef HAVE_EXPAT
     p->parser = XML_ParserCreate(NULL);
     if (p->parser == NULL) {


### PR DESCRIPTION
* src/ne_dates.c (ne_iso8601_parse): Remove redundant variable.

* src/ne_xml.c (ne_xml_create): Avoid use of strcpy.