### PR TITLE
OpenSSL 3.x related fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: Build and test
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   build:

--- a/src/ne_socket.c
+++ b/src/ne_socket.c
@@ -179,9 +179,6 @@ typedef struct in_addr ne_inet_addr;
 /* Socket read timeout */
 #define SOCKET_READ_TIMEOUT 120
 
-/* Internal read retry value */
-#define NE_SOCK_RETRY (-6)
-    
 /* Critical I/O functions on a socket: useful abstraction for easily
  * handling SSL I/O alongside raw socket I/O. */
 struct iofns {
@@ -674,7 +671,8 @@ static int error_ossl(ne_socket *sock, int sret)
     unsigned long err;
 
     if (errnum == SSL_ERROR_ZERO_RETURN) {
-	set_error(sock, _("Connection closed"));
+        set_error(sock, _("Connection closed"));
+        NE_DEBUG(NE_DBG_SSL, "ssl: Got TLS closure.\n");
         return NE_SOCK_CLOSED;
     }
     else if (errnum == SSL_ERROR_WANT_READ) {
@@ -2007,23 +2005,89 @@ void ne_sock_set_error(ne_socket *sock, const char *format, ...)
     va_end(params);
 }
 
-int ne_sock_close(ne_socket *sock)
+int ne_sock_shutdown(ne_socket *sock, unsigned int flags)
 {
     int ret;
 
-    /* Per API description - for an SSL connection, simply send the
-     * close_notify but do not wait for the peer's response. */
+    if (!flags) {
+        set_error(sock, _("Missing flags for socket shutdown"));
+        return NE_SOCK_ERROR;
+    }
+
 #if defined(HAVE_OPENSSL)
     if (sock->ssl) {
-        SSL_shutdown(sock->ssl);
+        int state = SSL_get_shutdown(sock->ssl);
+
+        NE_DEBUG(NE_DBG_SSL, "ssl: Shutdown state: %ssent | %sreceived.\n",
+                 (state & SSL_SENT_SHUTDOWN) ? "" : "not ",
+                 (state & SSL_RECEIVED_SHUTDOWN) ? "" : "not ");
+
+        if ((flags == NE_SOCK_BOTH || flags == NE_SOCK_SEND)
+            && (state & SSL_SENT_SHUTDOWN) == 0) {
+            NE_DEBUG(NE_DBG_SSL, "ssl: Sending closure.\n");
+            ret = SSL_shutdown(sock->ssl);
+
+            if (ret == 0) {
+                set_error(sock, _("Incomplete TLS closure"));
+                return NE_SOCK_RETRY;
+            }
+            else if (ret != 1) {
+                return error_ossl(sock, ret);
+            }
+        }
+
+	if (flags == NE_SOCK_RECV || flags == NE_SOCK_BOTH) {
+	    /* Returns whether the receive side is shutdown or not yet. */
+	    if ((state & SSL_RECEIVED_SHUTDOWN) == 0) {
+		set_error(sock, _("Incomplete TLS closure"));
+		return NE_SOCK_RETRY;
+	    }
+
+            /* For recv-only shutdown, must not complete TCP-level
+             * shutdown until the TLS shutdown is complete. */
+            if (flags == NE_SOCK_RECV) {
+                return 0;
+            }
+	}
+    }
+#elif defined(HAVE_GNUTLS)
+    if (sock->ssl) {
+        if (flags == NE_SOCK_RECV) {
+            /* unclear how to handle */
+            set_error(sock, _("Incomplete TLS closure"));
+            return NE_SOCK_RETRY;
+        }
+
+        ret = gnutls_bye(sock->ssl,
+                         flags == NE_SOCK_SEND ? GNUTLS_SHUT_WR :GNUTLS_SHUT_RDRW);
+        if (ret == GNUTLS_E_INTERRUPTED || ret == GNUTLS_E_AGAIN) {
+            return NE_SOCK_RETRY;
+        }
+    }
+#endif
+
+    ret = shutdown(sock->fd,
+                   flags == NE_SOCK_RECV ? SHUT_RD :
+		   (flags == NE_SOCK_SEND ? SHUT_WR : SHUT_RDWR));
+    if (ret < 0) {
+	int errnum = ne_errno;
+	set_strerror(sock, errnum);
+	return MAP_ERR(errnum);
+    }
+
+    return ret;
+}
+
+int ne_sock_close(ne_socket *sock)
+{
+    int ret = ne_sock_shutdown(sock, NE_SOCK_SEND);
+
+#if defined(HAVE_OPENSSL)
+    if (sock->ssl) {
 	SSL_free(sock->ssl);
     }
 #elif defined(HAVE_GNUTLS)
     if (sock->ssl) {
-        do {
-            ret = gnutls_bye(sock->ssl, GNUTLS_SHUT_WR);
-        } while (ret < 0
-                 && (ret == GNUTLS_E_INTERRUPTED || ret == GNUTLS_E_AGAIN));
         gnutls_deinit(sock->ssl);
     }
 #endif
@@ -2032,6 +2096,8 @@ int ne_sock_close(ne_socket *sock)
         ret = 0;
     else
         ret = ne_close(sock->fd);
+    sock->fd = -1;
+
     ne_free(sock);
     return ret;
 }

--- a/src/ne_socket.c
+++ b/src/ne_socket.c
@@ -817,6 +817,10 @@ static ssize_t error_gnutls(ne_socket *sock, ssize_t sret)
         ret = NE_SOCK_TRUNC;
         set_error(sock, _("Secure connection truncated"));
         break;
+    case GNUTLS_E_INVALID_SESSION:
+        ret = NE_SOCK_RESET;
+        set_error(sock, ("SSL socket terminated"));
+        break;
     case GNUTLS_E_PUSH_ERROR:
         ret = NE_SOCK_RESET;
         set_error(sock, ("SSL socket write failed"));

--- a/src/ne_socket.c
+++ b/src/ne_socket.c
@@ -2059,7 +2059,7 @@ int ne_sock_shutdown(ne_socket *sock, unsigned int flags)
         }
 
         ret = gnutls_bye(sock->ssl,
-                         flags == NE_SOCK_SEND ? GNUTLS_SHUT_WR :GNUTLS_SHUT_RDRW);
+                         flags == NE_SOCK_SEND ? GNUTLS_SHUT_WR : GNUTLS_SHUT_RDWR);
         if (ret == GNUTLS_E_INTERRUPTED || ret == GNUTLS_E_AGAIN) {
             return NE_SOCK_RETRY;
         }

--- a/src/ne_socket.h
+++ b/src/ne_socket.h
@@ -42,7 +42,8 @@ NE_BEGIN_DECLS
 #define NE_SOCK_RESET (-4)
 /* Secure connection was closed without proper SSL shutdown. */
 #define NE_SOCK_TRUNC (-5)
-/* Reserved value -   (-6) */
+/* Retry operation later. */
+#define NE_SOCK_RETRY (-6)
 
 /* ne_socket represents a TCP socket. */
 typedef struct ne_socket_s ne_socket;
@@ -227,10 +228,31 @@ int ne_sock_fd(const ne_socket *sock);
  * must be destroyed by caller using ne_iaddr_free. */
 ne_inet_addr *ne_sock_peer(ne_socket *sock, unsigned int *port);
 
-/* Close the socket and destroy the socket object.  If SSL is in use
- * for the socket, a closure alert is sent to initiate a clean
- * shutdown, but this function does not wait for the peer's response.
- * Returns zero on success, or non-zero on failure. */
+/* Flags for ne_sock_shutdown():  */
+#define NE_SOCK_RECV (1)
+#define NE_SOCK_SEND (2)
+#define NE_SOCK_BOTH (3)
+
+/* Shut down the socket in one or both directions, without destroying
+ * the socket object.  Flags must be one of NE_SOCK_RECV/SEND/BOTH.
+ * For a non-TLS socket, performs the directional shutdown according
+ * to flags.
+ * For a TLS socket:
+ * - if flags are NE_SOCK_SEND or NE_SOCK_BOTH, sends the TLS
+ *   close_notify.  Returns NE_SOCK_RETRY if the TLS connection has
+ *   not been closed by the peer.
+ * - if flags are NE_SOCK_RECV, returns NE_SOCK_RETRY if the 
+ *   TLS close_notify has not been closed by the peer.
+ * In NE_SOCK_SEND or NE_SOCK_BOTH is specified, and the bidirectional
+ * TLS shutdown has completed, the TCP shutdown will also be completed 
+ * as for a non-TLS socket. 
+*/
+int ne_sock_shutdown(ne_socket *sock, unsigned int flags);
+
+/* Close the socket if it is open, and destroy the socket object.  If
+ * SSL is in use for the socket, a closure alert is sent to initiate a
+ * clean shutdown, but this function does not wait for the peer's
+ * response.  Returns zero on success, or non-zero on failure. */
 int ne_sock_close(ne_socket *sock);
 
 /* Return current error string for socket. */

--- a/src/neon.vers
+++ b/src/neon.vers
@@ -32,4 +32,5 @@ NEON_0_32 {
     ne_strparam;
     ne_add_auth;
     ne_ssl_cert_hdigest;
+    ne_sock_shutdown;
 };

--- a/test/basic.c
+++ b/test/basic.c
@@ -144,6 +144,7 @@ static int do_range(off_t start, off_t end, const char *fail,
     ret = ne_get_range(sess, "/foo", &range, fd);
 
     close(fd);
+    ne_close_connection(sess);
     CALL(await_server());
     
     if (fail) {
@@ -242,9 +243,7 @@ static int dav_capabilities(void)
 	ONV(c.dav_executable != caps[n].exec,
 	    ("class2 was %d not %d", c.dav_executable, caps[n].exec));
 
-	CALL(await_server());
-
-        ne_session_destroy(sess);
+	CALL(destroy_and_wait(sess));
     }
 
     return OK;	
@@ -265,10 +264,7 @@ static int get(void)
     ONREQ(ne_get(sess, "/getit", fd));
     close(fd);
 
-    ne_session_destroy(sess);
-    CALL(await_server());
-
-    return OK;
+    return destroy_and_wait(sess);
 }
 
 #define CLASS_12 (NE_CAP_DAV_CLASS1 | NE_CAP_DAV_CLASS2)
@@ -309,9 +305,7 @@ static int options2(void)
             ("capabilities for 'DAV: %s' were 0x%x, expected 0x%x", 
              ts[n].hdrs, caps, ts[n].caps));
 
-        CALL(await_server());
-
-        ne_session_destroy(sess);
+        CALL(destroy_and_wait(sess));
     }
 
     return OK;  

--- a/test/common/child.c
+++ b/test/common/child.c
@@ -345,6 +345,11 @@ int dead_server(void)
     return OK;
 }
 
+int destroy_and_wait(ne_session *sess)
+{
+    ne_session_destroy(sess);
+    return await_server();
+}
 
 int await_server(void)
 {

--- a/test/common/child.c
+++ b/test/common/child.c
@@ -148,14 +148,26 @@ int reset_socket(ne_socket *sock)
 /* close 'sock', performing lingering close to avoid premature RST. */
 static int close_socket(ne_socket *sock)
 {
-#ifdef HAVE_SHUTDOWN
+    int ret;
     char buf[20];
-    int fd = ne_sock_fd(sock);
-    
-    shutdown(fd, 0);
+
+    ret = ne_sock_shutdown(sock, NE_SOCK_SEND);
+    if (ret == 0) {
+	NE_DEBUG(NE_DBG_SOCKET, "ssl: Socket cleanly closed.\n");
+    }
+    else {
+	NE_DEBUG(NE_DBG_SOCKET, "sock: Socket closed uncleanly: %s\n",
+		 ne_sock_error(sock));
+    }
+
+    NE_DEBUG(NE_DBG_SSL, "sock: Lingering close...\n");
+    ne_sock_read_timeout(sock, 5);
     while (ne_sock_read(sock, buf, sizeof buf) > 0);
-#endif
-    return ne_sock_close(sock);
+
+    NE_DEBUG(NE_DBG_SSL, "sock: Closing socket.\n");
+    ret = ne_sock_close(sock);
+    NE_DEBUG(NE_DBG_SSL, "sock: Socket closed (%d).\n", ret);
+    return ret;
 }
 
 /* This runs as the child process. */

--- a/test/common/child.h
+++ b/test/common/child.h
@@ -28,6 +28,7 @@
 #endif
 
 #include "ne_socket.h"
+#include "ne_session.h"
 
 /* Test which does DNS lookup on "localhost": this must be the first
  * named test. */
@@ -70,6 +71,9 @@ int new_spawn_server2(int count, server_fn fn, void *userdata,
 
 /* Blocks until child process exits, and gives return code of 'fn'. */
 int await_server(void);
+
+/* Destroys session 'sess' and then is equivalent to await_server. */
+int destroy_and_wait(ne_session *sess);
 
 /* Kills child process. */
 int reap_server(void);

--- a/test/compress.c
+++ b/test/compress.c
@@ -289,12 +289,9 @@ static int retry_compress_helper(ne_accept_response acceptor,
 
     ONN("got bad response body", failed != f_complete);
 
-    CALL(await_server());
-
     ne_request_destroy(req);
-    ne_session_destroy(sess);
 
-    return OK;
+    return destroy_and_wait(sess);
 }
 
 #define SSTRING(x) { x, sizeof(x) - 1 }

--- a/test/lock.c
+++ b/test/lock.c
@@ -580,12 +580,10 @@ static int fail_discover(void)
                       "</parse this, my friend>\n"));
     
     ret = ne_lock_discover(sess, "/foo", dummy_discover, NULL);
-    CALL(await_server());
 
     ONN("discovery okay for response with invalid XML!?", ret != NE_ERROR);
 
-    ne_session_destroy(sess);
-    return OK;
+    return destroy_and_wait(sess);
 }
 
 static int no_creds(void *ud, const char *realm, int attempt,
@@ -626,10 +624,7 @@ static int fail_lockauth(void)
          ret, ne_get_error(sess)));
     ne_lock_destroy(lock);
 
-    CALL(await_server());
-    ne_session_destroy(sess);
-
-    return OK;
+    return destroy_and_wait(sess);
 }
 
 /* Regression test for neon 0.25.0 regression in ne_lock() error

--- a/test/props.c
+++ b/test/props.c
@@ -52,8 +52,8 @@ static int patch_simple(void)
 		      "HTTP/1.1 200 Goferit\r\n"
 		      "Connection: close\r\n\r\n"));
     ONREQ(ne_proppatch(sess, "/fish", ops));
-    ne_session_destroy(sess);
-    return await_server();
+
+    return destroy_and_wait(sess);
 }
 
 #define RESP207 "HTTP/1.0 207 Stuff\r\n" "Server: foo\r\n\r\n"

--- a/test/request.c
+++ b/test/request.c
@@ -67,8 +67,7 @@ static int prepare_request(server_fn fn, void *ud)
 static int finish_request(void)
 {
     ne_request_destroy(def_req);
-    ne_session_destroy(def_sess);
-    return await_server();
+    return destroy_and_wait(def_sess);
 }
 
 #define RESP200 "HTTP/1.1 200 OK\r\n" "Server: neon-test-server\r\n"
@@ -128,6 +127,7 @@ static int expect_header_value(const char *name, const char *value,
 
     req = ne_request_create(sess, "FOO", "/bar");
     ONREQ(ne_request_dispatch(req));
+    ne_close_connection(sess);
     CALL(await_server());
     
     gotval = ne_get_response_header(req, name);
@@ -153,11 +153,11 @@ static int expect_response(const char *expect, server_fn fn, void *userdata)
 
     CALL(session_server(&sess, fn, userdata));
     CALL(run_request(sess, 200, construct_get, buf));
+    ne_session_destroy(sess);
     CALL(await_server());
 
     ONN("response body match", strcmp(buf->data, expect));
 
-    ne_session_destroy(sess);
     ne_buffer_destroy(buf);
     
     return OK;
@@ -193,11 +193,9 @@ static int expect_no_body(const char *method, const char *resp)
     ONV(any_request(sess, "/second"),
 	("second request on connection failed: %s",ne_get_error(sess)));
 
-    ON(await_server());
-
     ne_request_destroy(req);
-    ne_session_destroy(sess);
-    return OK;
+
+    return destroy_and_wait(sess);
 }
 
 static int reason_phrase(void)
@@ -207,6 +205,7 @@ static int reason_phrase(void)
     CALL(make_session(&sess, single_serve_string, RESP200
 		      "Connection: close\r\n\r\n"));
     ONREQ(any_request(sess, "/foo"));
+    ne_close_connection(sess);
     CALL(await_server());
     
     ONV(strcmp(ne_get_error(sess), "200 OK"),
@@ -434,13 +433,12 @@ static int test_persist_p(const char *response, const char *body, int proxy)
     /* Run it again. */
     ne_buffer_clear(buf);
     CALL(run_request(sess, 200, construct_get, buf));
-
+    ne_session_destroy(sess);
     ON(await_server());
 
     ONV(strcmp(buf->data, body),
 	("response #2 mismatch: [%s] not [%s]", buf->data, body));
 
-    ne_session_destroy(sess);
     ne_buffer_destroy(buf);
 
     return OK;
@@ -842,10 +840,8 @@ static int reset_headers(void)
     ONCMP("hello fair world", value, "response header", "X-Foo");
 
     ne_request_destroy(req);
-    ne_session_destroy(sess);
-    CALL(await_server());
 
-    return OK;
+    return destroy_and_wait(sess);
 }
 
 static int iterate_none(void)
@@ -862,11 +858,9 @@ static int iterate_none(void)
     ONN("iterator was not NULL for no headers",
         ne_response_header_iterate(req, NULL, NULL, NULL) != NULL);
 
-    CALL(await_server());
     ne_request_destroy(req);
-    ne_session_destroy(sess);
 
-    return OK;
+    return destroy_and_wait(sess);
 }
 
 #define MANY_HEADERS (90)
@@ -921,10 +915,8 @@ static int iterate_many(void)
     
     ne_buffer_destroy(buf);
     ne_request_destroy(req);
-    ne_session_destroy(sess);
-    CALL(await_server());
-    
-    return OK;
+
+    return destroy_and_wait(sess);
 }
 
 
@@ -1012,9 +1004,8 @@ static int expect_100_once(void)
     ne_set_request_body_buffer(req, body, sizeof(body));
     ONREQ(ne_request_dispatch(req));
     ne_request_destroy(req);
-    ne_session_destroy(sess);
-    CALL(await_server());
-    return OK;
+
+    return destroy_and_wait(sess);
 }
 
 /* regression test for enabling 100-continue without sending a body. */
@@ -1029,9 +1020,8 @@ static int expect_100_nobody(void)
     ne_set_request_flag(req, NE_REQFLAG_EXPECT100, 1);
     ONREQ(ne_request_dispatch(req));
     ne_request_destroy(req);
-    ne_session_destroy(sess);
 
-    return await_server();
+    return destroy_and_wait(sess);
 }
 
 struct body {
@@ -1117,11 +1107,9 @@ static int send_bodies(void)
 	    }
 
 	    ONREQ(ne_request_dispatch(req));
-	    
-	    CALL(await_server());
-	    
 	    ne_request_destroy(req);
-	    ne_session_destroy(sess);
+
+	    CALL(destroy_and_wait(sess));
 	}
     }
 
@@ -1462,13 +1450,10 @@ static int proxy_no_resolve(void)
                                 RESP200 "Content-Length: 0\r\n\r\n"));
     
     ret = any_request(sess, "/foo");
-    ne_session_destroy(sess);
     
     ONN("origin server name resolved when proxy used", ret == NE_LOOKUP);
     
-    CALL(await_server());
-    
-    return OK;
+    return destroy_and_wait(sess);
 }
 
 /* If the chunk size is entirely invalid, the request should be
@@ -1496,7 +1481,7 @@ static int abort_respbody(void)
      * contains an invalid chunk size. */
     ONN("invalid chunk size was accepted?",
 	any_request(sess, "/foo") != NE_ERROR);
-
+    ne_close_connection(sess);
     CALL(await_server());
     
     /* second request should fail since server has gone away. */
@@ -1536,7 +1521,7 @@ static int retry_after_abort(void)
 
     ONREQ(any_request(sess, "/first"));
     ONN("second request should fail", any_request(sess, "/second") == NE_OK);
-
+    ne_close_connection(sess);
     CALL(await_server());
 
     /* A third attempt to connect to the server should fail to
@@ -1561,7 +1546,7 @@ static int fail_statusline(void)
     
     ret = any_request(sess, "/fail");
     ONV(ret != NE_ERROR, ("request failed with %d not NE_ERROR", ret));
-    
+    ne_close_connection(sess);
     ONV(strstr(ne_get_error(sess), 
                "Could not parse response status line") == NULL,
 	("session error was `%s'", ne_get_error(sess)));
@@ -1758,10 +1743,8 @@ static int dup_method(void)
 
     ONREQ(ne_request_dispatch(req));
     ne_request_destroy(req);
-    ne_session_destroy(sess);
-    CALL(await_server());
 
-    return OK;
+    return destroy_and_wait(sess);
 }
 
 static int abortive_reader(void *userdata, const char *buf, size_t len)
@@ -1798,9 +1781,8 @@ static int abort_reader(void)
     /* test that the connection was closed. */
     ONN("connection not closed after aborted response",
         any_2xx_request(sess, "/failmeplease") == OK);
-    ne_session_destroy(sess);
-    CALL(await_server());
-    return OK;
+
+    return destroy_and_wait(sess);
 }
 
 /* attempt and fail to send request from offset 500 of /dev/null. */
@@ -2023,8 +2005,6 @@ static int icy_protocol(void)
     
     ONREQ(any_request(sess, "/foo"));
 
-    ne_session_destroy(sess);
-
     return await_server();
 }
 
@@ -2173,10 +2153,8 @@ static int dereg_progress(void)
     ne_set_progress(sess, NULL, NULL);
 
     ONREQ(any_request(sess, "/foo"));
-
-    ne_session_destroy(sess);
     
-    return await_server();    
+    return destroy_and_wait(sess);
 }
 
 static int addrlist(void)
@@ -2195,10 +2173,9 @@ static int addrlist(void)
 
     CALL(any_2xx_request(sess, "/blah"));
 
-    ne_session_destroy(sess);
     ne_iaddr_free(ia);
     
-    return await_server();
+    return destroy_and_wait(sess);
 }
 
 static int socks_session(ne_session **sess, struct socks_server *srv,
@@ -2235,8 +2212,7 @@ static int socks_proxy(void)
 
     CALL(any_2xx_request(sess, "/blee"));
 
-    ne_session_destroy(sess);
-    return await_server();
+    return destroy_and_wait(sess);
 }
 
 static int socks_v4_proxy(void)
@@ -2259,8 +2235,7 @@ static int socks_v4_proxy(void)
 
     ne_iaddr_free(srv.expect_addr);
 
-    ne_session_destroy(sess);
-    return await_server();
+    return destroy_and_wait(sess);
 }
 
 /* Server function which serves the request body back as the response
@@ -2352,8 +2327,7 @@ static int socks_fail(void)
 
     ne_iaddr_free(srv.expect_addr);
 
-    ne_session_destroy(sess);
-    return await_server();
+    return destroy_and_wait(sess);
 }
 
 static int safe_flags(void)

--- a/test/request.c
+++ b/test/request.c
@@ -2005,7 +2005,7 @@ static int icy_protocol(void)
     
     ONREQ(any_request(sess, "/foo"));
 
-    return await_server();
+    return destroy_and_wait(sess);
 }
 
 static void status_cb(void *userdata, ne_session_status status,


### PR DESCRIPTION
```
Add destroy_and_wait() helper for client side of tests,
use it and close connections consistently to allow a better
lingering-close implementation server-side in the future.

* test/common/child.c (destroy_and_wait): New function.

* test/request.c, test/props.c, test/lock.c: Use throughout.
```