### PR TITLE
Fix regression in authentication for request-target of "*" (#63):

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,6 @@
+Changes in release 0.32.2:
+* Fix auth handling for request-target of "*" (regressed since 0.31.x)
+
 Changes in release 0.32.1:
 * Fix configure CFLAGS handling in Kerberos detection.
 

--- a/test/utils.c
+++ b/test/utils.c
@@ -99,9 +99,9 @@ int any_request(ne_session *sess, const char *uri)
     return ret;
 }
 
-int any_2xx_request(ne_session *sess, const char *uri)
+int any_2xx_request_method(ne_session *sess, const char *method, const char *uri)
 {
-    ne_request *req = ne_request_create(sess, "GET", uri);
+    ne_request *req = ne_request_create(sess, method, uri);
     int ret = ne_request_dispatch(req);
     int klass = ne_get_status(req)->klass;
     const char *context = ne_get_response_header(req, "X-Neon-Context");
@@ -117,6 +117,11 @@ int any_2xx_request(ne_session *sess, const char *uri)
     }
     ne_request_destroy(req);
     return ret;
+}
+
+int any_2xx_request(ne_session *sess, const char *uri)
+{
+    return any_2xx_request_method(sess, "GET", uri);
 }
 
 int any_2xx_request_body(ne_session *sess, const char *uri)

--- a/test/utils.h
+++ b/test/utils.h
@@ -50,6 +50,10 @@ int any_2xx_request(ne_session *sess, const char *uri);
 /* As above but with a request body. */
 int any_2xx_request_body(ne_session *sess, const char *uri);
 
+/* As any_2xx_request but with a specified method. */
+int any_2xx_request_method(ne_session *sess, const char *method,
+                           const char *uri);
+
 /* makes *session, spawns server which will run 'fn(userdata,
  * socket)'.  sets error context if returns non-zero, i.e use like:
  * CALL(make_session(...)); */


### PR DESCRIPTION
```
* test/utils.c (any_2xx_request_method): Factored out of
  any_2xx_request.

* test/auth.c (serve_star_scope_checker, star_scope): New test.

* src/ne_auth.c (get_scope_path): Don't handle "*" here.
  (basic_challenge): Properly treat "*" as unscoped rather than simply
  CONNECT.
  (request_basic): Only check scope if there is a configured scope.
```