### PR TITLE
make: ignore docs if they do not exist

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -130,16 +130,18 @@ install-docs: install-man install-html
 install-html:
 	$(INSTALL) -d $(DESTDIR)$(docdir)/html
 	for d in doc/html/*.html; do \
-		$(INSTALL_DATA) $$d $(DESTDIR)$(docdir)/html; \
+		test ! -f $$d || $(INSTALL_DATA) $$d $(DESTDIR)$(docdir)/html; \
 	done
 
 install-man:
 	$(INSTALL) -d $(DESTDIR)$(man3dir)
 	$(INSTALL) -d $(DESTDIR)$(man1dir)
 	for m in doc/man/*.3; do \
-	 $(INSTALL_DATA) $$m $(DESTDIR)$(man3dir); done
+		test ! -f $$m || $(INSTALL_DATA) $$m $(DESTDIR)$(man3dir); \
+	done
 	for m in doc/man/*.1; do \
-	 $(INSTALL_DATA) $$m $(DESTDIR)$(man1dir); done
+		test ! -f $$m || $(INSTALL_DATA) $$m $(DESTDIR)$(man1dir); \
+	done
 
 install: install-@ALLOW_INSTALL@
 


### PR DESCRIPTION
Related to https://github.com/notroj/neon/issues/67

Confirmed that this patch works on Windows with MSYS2 from a git clone with
```bash
./autogen.sh
mkdir build-64bit
cd build-64bit
../configure --prefix=/local64 --disable-{nls,debug,webdav}
make -j $(nproc)
make install
```