### PR TITLE
Revert "Advertise TS_SSL feature with OpenSSL >= 1.1.0."

### DIFF
--- a/macros/neon.m4
+++ b/macros/neon.m4
@@ -960,13 +960,9 @@ yes|openssl)
    AC_CHECK_HEADERS(openssl/ssl.h openssl/opensslv.h,,
    [AC_MSG_ERROR([OpenSSL headers not found, cannot enable SSL support])])
 
+   # Enable EGD support if using 0.9.7 or newer
    NE_CHECK_OPENSSLVER(ne_cv_lib_ssl097, 0.9.7, 0x00907000L)
-   NE_CHECK_OPENSSLVER(ne_cv_lib_ssl110, 1.1.0, 0x10100000L)
-   if test "$ne_cv_lib_ssl110" = "yes"; then
-      NE_ENABLE_SUPPORT(SSL, [SSL support enabled, using OpenSSL $NE_SSL_VERSION])
-      AC_DEFINE(HAVE_OPENSSL11, 1, [Enable OpenSSL 1.1 support])
-   elif test "$ne_cv_lib_ssl097" = "yes"; then
-      # Enable EGD support if using 0.9.7 or newer
+   if test "$ne_cv_lib_ssl097" = "yes"; then
       AC_MSG_NOTICE([OpenSSL >= 0.9.7; EGD support not needed in neon])
       NE_ENABLE_SUPPORT(SSL, [SSL support enabled, using OpenSSL $NE_SSL_VERSION])
       NE_CHECK_FUNCS(CRYPTO_set_idptr_callback SSL_SESSION_cmp)
@@ -1074,11 +1070,8 @@ CC/CFLAGS/LIBS must be used to make the POSIX library interfaces
 available]),,
 enable_threadsafe_ssl=no)
 
-case ${enable_threadsafe_ssl}X${ne_cv_lib_ssl110} in
-*Xyes)
-  NE_ENABLE_SUPPORT(TS_SSL, [OpenSSL is natively thread-safe])
-  ;;
-posixX*|yesX*)
+case $enable_threadsafe_ssl in
+posix|yes)
   ne_pthr_ok=yes
   AC_CHECK_FUNCS([pthread_mutex_init pthread_mutex_lock],,[ne_pthr_ok=no])
   if test "${ne_pthr_ok}" = "no"; then

--- a/src/ne_openssl.c
+++ b/src/ne_openssl.c
@@ -1194,8 +1194,8 @@ char *ne_vstrhash(unsigned int flags, va_list ap)
     return ne__strhash2hex(v, vlen, flags);
 }
 
-#if defined(NE_HAVE_TS_SSL) && OPENSSL_VERSION_NUMBER < 0x10100000L
-/* From OpenSSL 1.1.0 locking callbacks are no longer needed. */
+#if defined(NE_HAVE_TS_SSL) && OPENSSL_VERSION_NUMBER < 0x10101000L
+/* For OpenSSL 1.1.1 locking callbacks are no longer need at all. */
 #define WITH_OPENSSL_LOCKING (1)
 
 /* Implementation of locking callbacks to make OpenSSL thread-safe.


### PR DESCRIPTION
This reverts commit 281c84fc3996c757efdf6e9b3f906d7a1fc08b1d.

Indeed openssl can be built on toolchains without threads support which will result in the following build failure:

```
ne_openssl.c:43:10: fatal error: pthread.h: No such file or directory
   43 | #include <pthread.h>
      |          ^~~~~~~~~~~
```

Fixes:
 - http://autobuild.buildroot.org/results/da995ef26001357e51a5907de9c6111b9ff89bdf

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>