### PR TITLE
OpenSSL vs pthreads fix

### DIFF
--- a/src/ne_openssl.c
+++ b/src/ne_openssl.c
@@ -37,7 +37,9 @@
 #include <openssl/opensslv.h>
 #include <openssl/evp.h>
 
-#ifdef NE_HAVE_TS_SSL
+#if defined(NE_HAVE_TS_SSL) && OPENSSL_VERSION_NUMBER < 0x10100000L
+/* From OpenSSL 1.1.0 locking callbacks are no longer needed. */
+#define WITH_OPENSSL_LOCKING (1)
 #include <stdlib.h> /* for abort() */
 #ifndef _WIN32
 #include <pthread.h>
@@ -1194,10 +1196,7 @@ char *ne_vstrhash(unsigned int flags, va_list ap)
     return ne__strhash2hex(v, vlen, flags);
 }
 
-#if defined(NE_HAVE_TS_SSL) && OPENSSL_VERSION_NUMBER < 0x10100000L
-/* From OpenSSL 1.1.0 locking callbacks are no longer needed. */
-#define WITH_OPENSSL_LOCKING (1)
-
+#ifdef WITH_OPENSSL_LOCKING
 /* Implementation of locking callbacks to make OpenSSL thread-safe.
  * If the OpenSSL API was better designed, this wouldn't be necessary.
  * In OpenSSL releases without CRYPTO_set_idptr_callback, it's not


### PR DESCRIPTION
* src/ne_openssl.c: Fix possible build failures w/o pthreads for OpenSSL 1.1.0+.  (fixes #71)