### PR TITLE
Relax strictness of usernames allowed with Digest without requiring

### DIFF
--- a/test/auth.c
+++ b/test/auth.c
@@ -1030,6 +1030,7 @@ static int digest_username_star(void)
         const char *username_raw, *username_star;
     } ts[] = {
         { "Aladdin", NULL },
+        { "aladdin@cave.example.com", NULL },
         { "Ałâddín", "UTF-8''A%c5%82%c3%a2dd%c3%adn" },
         { "Jäsøn Doe", "UTF-8''J%c3%a4s%c3%b8n%20Doe" },
         { "foo bar",  "UTF-8''foo%20bar"},


### PR DESCRIPTION
```
Relax strictness of usernames allowed with Digest without requiring userhash/ext-param quoting (closes #78):

* src/ne_auth.c (unsafe_username): New function.
  (get_digest_h_urp): Use it, rather than ne_strparam() to
  determine whether the passed username is safe to use quoted.

* test/auth.c (digest_username_star): Test for @ in usernames.
```