### PR TITLE
Fix non-SSL build

### DIFF
--- a/macros/neon.m4
+++ b/macros/neon.m4
@@ -658,7 +658,7 @@ NE_LARGEFILE
 AC_REPLACE_FUNCS(strcasecmp)
 
 AC_CHECK_FUNCS([signal setvbuf setsockopt stpcpy poll fcntl getsockopt \
-                explicit_bzero sendmsg])
+                explicit_bzero sendmsg gettimeofday])
 
 if test "x${ac_cv_func_poll}${ac_cv_header_sys_poll_h}y" = "xyesyesy"; then
   AC_DEFINE([NE_USE_POLL], 1, [Define if poll() should be used])

--- a/src/ne_auth.c
+++ b/src/ne_auth.c
@@ -358,6 +358,7 @@ static char *get_cnonce(void)
         /* Fallback sources of random data: all bad, but no good sources
          * are available. */
         ne_buffer *buf = ne_buffer_create();
+        char *ret;
 
         {
 #ifdef HAVE_GETTIMEOFDAY
@@ -378,7 +379,9 @@ static char *get_cnonce(void)
             ne_buffer_snprintf(buf, 32, "%lu", (unsigned long) pid);
         }
 
-        return ne_strhash(NE_HASH_MD5, buf->data, NULL);
+        ret = ne_strhash(NE_HASH_MD5, buf->data, NULL);
+        ne_buffer_destroy(buf);
+        return ret;
     }
 }
 

--- a/src/ne_auth.c
+++ b/src/ne_auth.c
@@ -335,8 +335,9 @@ static void clean_session(auth_session *sess)
 /* Returns client nonce string. */
 static char *get_cnonce(void) 
 {
+#ifdef NE_HAVE_SSL
     unsigned char data[32];
-
+#endif
 #ifdef HAVE_GNUTLS
     if (1) {
 #if LIBGNUTLS_VERSION_NUMBER < 0x020b00
@@ -357,7 +358,6 @@ static char *get_cnonce(void)
         /* Fallback sources of random data: all bad, but no good sources
          * are available. */
         ne_buffer *buf = ne_buffer_create();
-        char *ret;
 
         {
 #ifdef HAVE_GETTIMEOFDAY
@@ -378,7 +378,7 @@ static char *get_cnonce(void)
             ne_buffer_snprintf(buf, 32, "%lu", (unsigned long) pid);
         }
 
-        ret = ne_strhash(NE_HASH_MD5, buf->data);
+        return ne_strhash(NE_HASH_MD5, buf->data, NULL);
     }
 }
 

--- a/src/ne_stubssl.c
+++ b/src/ne_stubssl.c
@@ -102,7 +102,7 @@ void ne_ssl_context_set_flag(ne_ssl_context *ctx, int flag, int value) {}
 
 void ne_ssl_context_destroy(ne_ssl_context *ctx) {}
 
-int ne_ssl_cert_digest(const ne_ssl_certificate *cert, char digest[60])
+int ne_ssl_cert_digest(const ne_ssl_certificate *cert, char *digest)
 {
     return -1;
 }


### PR DESCRIPTION
```
* src/ne_auth.c (get_cnonce): Fix non-SSL build and warnings in
  SSL build for regressions in 3cc1e6916bfba255ab7234ad32428b743b521b63.
```