### PR TITLE
Fix mingw cross-builds

### DIFF
--- a/macros/neon.m4
+++ b/macros/neon.m4
@@ -363,7 +363,7 @@ AC_REQUIRE([NE_CHECK_OS])
 
 AC_CACHE_CHECK([for library containing $1], [ne_cv_libsfor_$1], [
   case $ne_cv_os_uname in
-  MINGW*)
+  MINGW*|MSYS_NT*)
     ;;
   *)
     case $1 in
@@ -391,7 +391,7 @@ AC_CACHE_CHECK([for library containing $1], [ne_cv_libsfor_$1], [
     ne_cv_libsfor_$1="not found"
     for lib in $2; do
       case $ne_cv_os_uname in
-      MINGW*)
+      MINGW*|MSYS_NT*)
         case $lib in
         ws2_32)
           ne__prologue="#include <winsock2.h>"

--- a/macros/neon.m4
+++ b/macros/neon.m4
@@ -427,7 +427,7 @@ AC_CACHE_CHECK([for library containing $1], [ne_cv_libsfor_$1], [
     LIBS=$ne_sl_save_LIBS
   ])
 ])
-AC_CHECK_HEADER(wspiapi.h)
+AC_CHECK_HEADERS([wspiapi.h])
 
 if test "$ne_cv_libsfor_$1" = "not found"; then
    m4_if([$4], [], [AC_MSG_ERROR([could not find library containing $1])], [$4])

--- a/macros/neon.m4
+++ b/macros/neon.m4
@@ -549,7 +549,12 @@ else
      NEON_FORMAT(off64_t)
      ne_lfsok=no
      AC_CHECK_FUNCS([strtoll strtoq], [ne_lfsok=yes; break])
-     AC_CHECK_FUNCS([lseek64 fstat64], [], [ne_lfsok=no; break])
+     AS_CASE([$ne_cv_os_uname],
+       [MINGW*|MSYS_NT*],
+         [AC_CHECK_FUNCS([lseek64], [], [ne_lfsok=no; break])],
+       dnl Default:
+         [AC_CHECK_FUNCS([lseek64 fstat64], [], [ne_lfsok=no; break])]
+     )
      if test x$ne_lfsok = xyes; then
        NE_ENABLE_SUPPORT(LFS, [LFS (large file) support enabled])
        NEON_CFLAGS="$NEON_CFLAGS -D_LARGEFILE64_SOURCE -DNE_LFS"

--- a/macros/neon.m4
+++ b/macros/neon.m4
@@ -465,7 +465,7 @@ AC_CACHE_CHECK([for uname], ne_cv_os_uname, [
  dnl # NOTE: Quick-and-dirty approach to handle building libneon
  dnl # for Windows using Linux environments with mingw packages:
  dnl # other code in this script checks for "MINGW*" matches.
- dnl #  ./configure --prefix=/usr/i686-w64-mingw32 --host=i686-w64-mingw32
+ dnl #  ./configure --prefix=/usr/i686-w64-mingw32 --host=i686-w64-mingw32 PKG_CONFIG_PATH=/usr/i686-w64-mingw32/lib/pkgconfig
  case x"$host" in
     x*mingw*) ne_cv_os_uname="MINGW-$host" ;;
  esac

--- a/macros/neon.m4
+++ b/macros/neon.m4
@@ -471,14 +471,18 @@ AC_CACHE_CHECK([for uname], ne_cv_os_uname, [
  esac
 ])
 
-if test "$ne_cv_os_uname" = "Darwin"; then
+AS_CASE([x"$ne_cv_os_uname"],
+[x"Darwin"], [
   CPPFLAGS="$CPPFLAGS -no-cpp-precomp"
   LDFLAGS="$LDFLAGS -flat_namespace" 
   # poll has various issues in various Darwin releases
   if test x${ac_cv_func_poll+set} != xset; then
     ac_cv_func_poll=no
   fi
-fi
+],
+[xMINGW*|xMSYS*],
+  [NEON_LIBS="$NEON_LIBS -lws2_32"]
+)dnl AS_CASE
 ])
 
 AC_DEFUN([NEON_COMMON_CHECKS], [

--- a/macros/neon.m4
+++ b/macros/neon.m4
@@ -459,6 +459,15 @@ AC_DEFUN([NE_CHECK_OS], [
 # Check for Darwin, which needs extra cpp and linker flags.
 AC_CACHE_CHECK([for uname], ne_cv_os_uname, [
  ne_cv_os_uname=`uname -s 2>/dev/null`
+ dnl # Check with autoconf cross-build request, particularly the
+ dnl # "host" (system type where build program will be executed)
+ dnl # NOTE: Quick-and-dirty approach to handle building libneon
+ dnl # for Windows using Linux environments with mingw packages:
+ dnl # other code in this script checks for "MINGW*" matches.
+ dnl #  ./configure --prefix=/usr/i686-w64-mingw32 --host=i686-w64-mingw32
+ case x"$host" in
+    x*mingw*) ne_cv_os_uname="MINGW-$host" ;;
+ esac
 ])
 
 if test "$ne_cv_os_uname" = "Darwin"; then

--- a/macros/neon.m4
+++ b/macros/neon.m4
@@ -427,6 +427,7 @@ AC_CACHE_CHECK([for library containing $1], [ne_cv_libsfor_$1], [
     LIBS=$ne_sl_save_LIBS
   ])
 ])
+AC_CHECK_HEADER(wspiapi.h)
 
 if test "$ne_cv_libsfor_$1" = "not found"; then
    m4_if([$4], [], [AC_MSG_ERROR([could not find library containing $1])], [$4])
@@ -747,6 +748,9 @@ AC_CHECK_TYPES(socklen_t,,
 #endif
 #ifdef HAVE_SYS_SOCKET_H
 # include <sys/socket.h>
+#endif
+#ifdef _WIN32
+# include <ws2tcpip.h>
 #endif
 ])
 

--- a/src/ne_socket.c
+++ b/src/ne_socket.c
@@ -60,7 +60,9 @@
 #ifdef WIN32
 #include <winsock2.h>
 #include <stddef.h>
+#if (defined USE_GETADDRINFO) || (HAVE_SOCKLEN_T)
 #include <ws2tcpip.h>
+#endif
 #ifdef HAVE_WSPIAPI_H
 #include <wspiapi.h>
 #endif

--- a/src/ne_socket.c
+++ b/src/ne_socket.c
@@ -60,8 +60,8 @@
 #ifdef WIN32
 #include <winsock2.h>
 #include <stddef.h>
-#ifdef USE_GETADDRINFO
 #include <ws2tcpip.h>
+#ifdef HAVE_WSPIAPI_H
 #include <wspiapi.h>
 #endif
 #endif


### PR DESCRIPTION
While preparing a cross-build procedure (to compile NUT for Windows on a Linux machine with mingw) recently, I've been stuck with inability to build libneon on such platform out of the box. And also not on MSYS2 (a MinGW environment bundle for native Windows).

Looking around, I found a concise set of fixes among OBS recipes at https://build.opensuse.org/package/show/windows:mingw:win32/mingw32-libneon which got me started on this PR (with some creative adaptation).

Now I can configure and build neon on both Windows MSYS2 and Linux mingw environments, and use it as a shared DLL library for NUT. The hack is a bit dirty (setting `ne_cv_os_uname` in certain conditions) but making a clean cross-build solution needs larger autoconf script changes toward that goal :)

Example Linux-mingw cross-build (tested in Ubuntu) looks like this:
````
./configure --prefix=/usr/i686-w64-mingw32 --host=i686-w64-mingw32 \
    PKG_CONFIG_PATH=/usr/i686-w64-mingw32/lib/pkgconfig \
    CFLAGS="-D_POSIX=1 -I/usr/i686-w64-mingw32/include"
````
or for 64-bit builds:
````
./configure --prefix=/usr/x86_64-w64-mingw32 --host=x86_64-w64-mingw32 \
    PKG_CONFIG_PATH=/usr/x86_64-w64-mingw32/lib/pkgconfig \
    CFLAGS="-D_POSIX=1 -I/usr/x86_64-w64-mingw32/include"
````

For MSYS2 a plain `./configure` should now suffice for the native target.

Prerequisites like `libxml2` should be built and installed first, but were trivial to do so :)

Also note that to `sudo make install` from Git sources, I must `make all docs` explicitly first (otherwise it fails to install manpages), and that libtool installs "executable" MinGW DLL files like `libneon-27.dll` here into "bin", e.g. `/usr/i686-w64-mingw32/bin` location. The `libneon.dll.a` (hmmm) and `neon.pc` are provided to help build against it.