### PR TITLE
Make ne_ssl_trust_default_ca a noop for non-SSL sessions

### DIFF
--- a/src/ne_gnutls.c
+++ b/src/ne_gnutls.c
@@ -1080,15 +1080,17 @@ void ne_ssl_context_trustcert(ne_ssl_context *ctx, const ne_ssl_certificate *cer
 
 void ne_ssl_trust_default_ca(ne_session *sess)
 {
+    if (sess->ssl_context) {
 #ifdef NE_SSL_CA_BUNDLE
-    gnutls_certificate_set_x509_trust_file(sess->ssl_context->cred,
-                                           NE_SSL_CA_BUNDLE,
-                                           GNUTLS_X509_FMT_PEM);
+        gnutls_certificate_set_x509_trust_file(sess->ssl_context->cred,
+                                               NE_SSL_CA_BUNDLE,
+                                               GNUTLS_X509_FMT_PEM);
 #elif defined(HAVE_GNUTLS_CERTIFICATE_SET_X509_SYSTEM_TRUST)
-    int rv = gnutls_certificate_set_x509_system_trust(sess->ssl_context->cred);
+        int rv = gnutls_certificate_set_x509_system_trust(sess->ssl_context->cred);
 
-    NE_DEBUG(NE_DBG_SSL, "ssl: System certificates trusted (%d)\n", rv);
+        NE_DEBUG(NE_DBG_SSL, "ssl: System certificates trusted (%d)\n", rv);
 #endif
+    }
 }
 
 /* Read the contents of file FILENAME into *DATUM. */

--- a/src/ne_openssl.c
+++ b/src/ne_openssl.c
@@ -810,13 +810,15 @@ void ne_ssl_context_trustcert(ne_ssl_context *ctx, const ne_ssl_certificate *cer
 
 void ne_ssl_trust_default_ca(ne_session *sess)
 {
-    X509_STORE *store = SSL_CTX_get_cert_store(sess->ssl_context->ctx);
+    if (sess->ssl_context) {
+        X509_STORE *store = SSL_CTX_get_cert_store(sess->ssl_context->ctx);
     
 #ifdef NE_SSL_CA_BUNDLE
-    X509_STORE_load_locations(store, NE_SSL_CA_BUNDLE, NULL);
+        X509_STORE_load_locations(store, NE_SSL_CA_BUNDLE, NULL);
 #else
-    X509_STORE_set_default_paths(store);
+        X509_STORE_set_default_paths(store);
 #endif
+    }
 }
 
 /* Find a friendly name in a PKCS12 structure the hard way, without

--- a/src/ne_session.h
+++ b/src/ne_session.h
@@ -281,7 +281,8 @@ void ne_ssl_set_clicert(ne_session *sess, const ne_ssl_client_cert *clicert);
 void ne_ssl_trust_cert(ne_session *sess, const ne_ssl_certificate *cert);
 
 /* If the SSL library provided a default set of CA certificates, trust
- * this set of CAs. */
+ * this set of CAs. This function has no effect for non-SSL
+ * sessions. */
 void ne_ssl_trust_default_ca(ne_session *sess);
 
 /* Callback used to load a client certificate on demand.  If dncount

--- a/test/ssl.c
+++ b/test/ssl.c
@@ -1823,6 +1823,7 @@ static int nonssl_trust(void)
     ne_session *sess = ne_session_create("http", "www.example.com", 80);
     
     ne_ssl_trust_cert(sess, def_ca_cert);
+    ne_ssl_trust_default_ca(sess);
     
     ne_session_destroy(sess);
 


### PR DESCRIPTION
```
Make ne_ssl_trust_default_ca a noop for non-SSL sessions, like ne_ssl_trust_cert.

* src/ne_gnutls.c (ne_ssl_trust_default_ca),
  src/ne_openssl.c (ne_ssl_trust_default_ca): Noop for non-SSL session.

* test/ssl.c (nonssl_trust): Test that ne_ssl_trust_default_ca() is a 
  noop for non-SSL sessions.
```