### PR TITLE
Use GnuTLS system trust function if available.

### DIFF
--- a/macros/neon.m4
+++ b/macros/neon.m4
@@ -1034,6 +1034,7 @@ gnutls)
                   gnutls_certificate_get_x509_cas \
                   gnutls_x509_crt_sign2 \
                   gnutls_certificate_set_retrieve_function2 \
+                  gnutls_certificate_set_x509_system_trust \
                   gnutls_privkey_import_ext])
 
    # fail if gnutls_x509_crt_sign2 is not found (it was introduced in 1.2.0, which is required)

--- a/src/ne_gnutls.c
+++ b/src/ne_gnutls.c
@@ -1084,6 +1084,10 @@ void ne_ssl_trust_default_ca(ne_session *sess)
     gnutls_certificate_set_x509_trust_file(sess->ssl_context->cred,
                                            NE_SSL_CA_BUNDLE,
                                            GNUTLS_X509_FMT_PEM);
+#elif defined(HAVE_GNUTLS_CERTIFICATE_SET_X509_SYSTEM_TRUST)
+    int rv = gnutls_certificate_set_x509_system_trust(sess->ssl_context->cred);
+
+    NE_DEBUG(NE_DBG_SSL, "ssl: System certificates trusted (%d)\n", rv);
 #endif
 }
 


### PR DESCRIPTION
```
* src/ne_gnutls.c (ne_ssl_trust_default_ca): Use gnutls_certificate_set_x509_system_trust() if available.

* macros/neon.m4 (NEON_SSL): Check for presence of gnutls_certificate_set_x509_system_trust.
```