### PR TITLE
Check libproxy during session creation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -91,6 +91,14 @@ if test "$enable_memleak" = "yes"; then
   ALLOW_INSTALL=memleak
 fi
 
+AC_ARG_ENABLE(auto-libproxy, 
+  AS_HELP_STRING([--enable-auto-libproxy],
+                 [for using libproxy during session creation]))
+
+if test "$enable_auto_libproxy" = "yes"; then
+  AC_DEFINE(NE_ENABLE_AUTO_LIBPROXY, 1, [to use libproxy automatically])
+fi
+
 # Enable tests for optional features
 TESTS="\$(BASIC_TESTS)"
 HELPERS=""

--- a/src/ne_session.c
+++ b/src/ne_session.c
@@ -200,6 +200,10 @@ ne_session *ne_session_create(const char *scheme,
     /* Set flags which default to on: */
     sess->flags[NE_SESSFLAG_PERSIST] = 1;
 
+#ifdef NE_ENABLE_AUTO_LIBPROXY
+    ne_session_system_proxy(sess, 0);
+#endif
+
     return sess;
 }
 


### PR DESCRIPTION
Give libproxy a chance to automatically set the correct proxy without additional client configuration.