### PR TITLE
autoconf macro update

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -11,7 +11,7 @@ This configure script may be copied, distributed and modified under the
 terms of the GNU Library General Public license; see src/COPYING.LIB for
 more details.])
 
-AC_CONFIG_HEADER(config.h)
+AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_SRCDIR(src/ne_request.c)
 
 NEON_WITH_LIBS

--- a/macros/neon-test.m4
+++ b/macros/neon-test.m4
@@ -30,7 +30,6 @@ AC_REQUIRE([NEON_COMMON_CHECKS])
 AC_REQUIRE([NE_FORMAT_TIMET])
 
 AC_REQUIRE([AC_TYPE_PID_T])
-AC_REQUIRE([AC_HEADER_TIME])
 
 dnl NEON_XML_PARSER may add things (e.g. -I/usr/local/include) to 
 dnl CPPFLAGS which make "gcc -Werror" fail in NEON_FORMAT; suggest

--- a/macros/neon.m4
+++ b/macros/neon.m4
@@ -503,8 +503,6 @@ AC_REQUIRE([NE_CHECK_OS])
 
 AC_REQUIRE([AC_PROG_MAKE_SET])
 
-AC_REQUIRE([AC_HEADER_STDC])
-
 AC_CHECK_HEADERS([errno.h stdarg.h string.h stdlib.h sys/uio.h])
 
 NEON_FORMAT(size_t,,u) dnl size_t is unsigned; use %u formats


### PR DESCRIPTION
```
* configure.ac, macros/neon-test.m4, macros/neon.m4:
  Update to avoid warnings with autoconf 2.70+. No functional change.
```