### PR TITLE
Fix hash algorithm strength comparison

### DIFF
--- a/src/ne_auth.c
+++ b/src/ne_auth.c
@@ -1385,7 +1385,8 @@ static void insert_challenge(struct auth_challenge **list, struct auth_challenge
         if (chall->protocol->strength > cur->protocol->strength
             || (cur->protocol->id == NE_AUTH_DIGEST
                 && chall->protocol->id == NE_AUTH_DIGEST
-                && chall->alg > cur->alg)) {
+                && chall->alg && cur->alg
+                && chall->alg->hash > cur->alg->hash)) {
             break;
         }
     }


### PR DESCRIPTION
```
* src/ne_auth.c (insert_challenge): Compare hash algorithm
  strength correctly after d4f70fc3b25797041e57600893a93e5df20bc327
  although it appears to work (usually?) correctly anyway.
```
