### PR TITLE
Allow suppressing build of test suite child/server handling functions

### DIFF
--- a/macros/neon-test.m4
+++ b/macros/neon-test.m4
@@ -43,3 +43,7 @@ AC_CHECK_FUNCS(pipe isatty usleep shutdown setlocale gethostname)
 AC_REQUIRE([NE_FIND_AR])
 
 ])
+
+AC_DEFUN([NEON_TEST_WITHOUT_CHILD], [
+AC_DEFINE([NEON_TEST_NO_CHILD], 1, [Define if test suite child process handling is not needed])
+])

--- a/test/common/child.c
+++ b/test/common/child.c
@@ -50,6 +50,8 @@
 #include "tests.h"
 #include "child.h"
 
+#ifndef NEON_NO_TEST_CHILD
+
 static pid_t child = 0;
 
 int clength;
@@ -537,3 +539,5 @@ int serve_file(ne_socket *sock, void *ud)
 
     return OK;
 }
+
+#endif /* NEON_NO_TEST_CHILD */

--- a/test/common/tests.c
+++ b/test/common/tests.c
@@ -115,6 +115,8 @@ void t_warning(const char *str, ...)
 #define W_RED(m) do { if (use_colour) W("\033[41;37;01m"); \
 W(m); if (use_colour) W("\033[00m\n"); } while (0);
 
+#ifndef NEON_NO_TEST_CHILD
+
 /* Signal handler for child processes. */
 static void child_segv(int signo)
 {
@@ -148,6 +150,7 @@ void in_child(void)
     signal(SIGABRT, child_segv);
     flag_child = 1;
 }
+#endif
 
 static const char dots[] = "......................";
 
@@ -221,9 +224,11 @@ int main(int argc, char *argv[])
 	return -1;
     }
 
+#ifndef NEON_NO_TEST_CHILD
     /* install special SEGV handler. */
     signal(SIGSEGV, parent_segv);
     signal(SIGABRT, parent_segv);
+#endif
 
     /* test the "no-debugging" mode of ne_debug. */
     ne_debug_init(NULL, 0);
@@ -374,8 +379,10 @@ int main(int argc, char *argv[])
 	    break;
 	}
 
+#ifndef NEON_NO_TEST_CHILD
 	reap_server();
-            
+#endif
+
         if (quiet) {
             print_prefix(n);
         }


### PR DESCRIPTION
```
Allow suppressing build of test suite child/server handling functions
for embedded neon build, via NEON_TEST_NO_CHILD m4 macro.

* macros/neon-test.m4: Define NEON_TEST_NO_CHILD.

* test/common/child.c, test/common/tests.c: Suppress code dealing with child/server processes if NEON_TEST_NO_CHILD is defined.
```
