### PR TITLE
fix crash on invalid lock in litmus test

### DIFF
--- a/src/ne_locks.c
+++ b/src/ne_locks.c
@@ -310,6 +310,8 @@ void ne_lock_using_resource(ne_request *req, const char *uri, int depth)
     /* Iterate over the list of stored locks to see if any of them
      * apply to this resource */
     for (item = lrc->store->locks; item != NULL; item = item->next) {
+	if (!item->lock->uri.path)
+	    continue;
 	
 	match = 0;
 	


### PR DESCRIPTION
fix crash on invalid lock in litmus test

This commit is from 2016 for an issue I ran into with litmus when I was bringing [lighttpd mod_webdav](https://wiki.lighttpd.net/mod_webdav) up to RFC4918. I do not have immediate example of the item it fixes, but the change is only a couple lines and the commit message describes the issues it fixes.

If there are questions, please ask and I'll add more details.

Similar in age to https://github.com/notroj/litmus/pull/6