### PR TITLE
ne_openssl: Fix the build with libressl

### DIFF
--- a/src/ne_openssl.c
+++ b/src/ne_openssl.c
@@ -581,7 +581,7 @@ ne_ssl_context *ne_ssl_context_create(int mode)
         /* enable workarounds for buggy SSL server implementations */
         SSL_CTX_set_options(ctx->ctx, SSL_OP_ALL);
         SSL_CTX_set_verify(ctx->ctx, SSL_VERIFY_PEER, verify_callback);
-#if !defined(LIBRESSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x10101000L
+#if LIBRESSL_VERSION_NUMBER >= 0x3040000fL || (!defined(LIBRESSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x10101000L)
         SSL_CTX_set_post_handshake_auth(ctx->ctx, 1);
 #endif
     } else if (mode == NE_SSL_CTX_SERVER) {
@@ -1122,7 +1122,9 @@ static const EVP_MD *hash_to_md(unsigned int flags)
     case NE_HASH_SHA256: return EVP_sha256();
 #ifdef HAVE_OPENSSL11
     case NE_HASH_SHA512: return EVP_sha512();
+#ifndef LIBRESSL_VERSION_NUMBER
     case NE_HASH_SHA512_256: return EVP_sha512_256();
+#endif
 #endif
     default: break;
     }


### PR DESCRIPTION
* Libressl 3.7 currently doesn't provide `EVP_sha512_256()`.
* Libressl 3.4 added `SSL_CTX_set_post_handshake_auth()`.