### PR TITLE
IPv6 test fixes

### DIFF
--- a/test/common/child.c
+++ b/test/common/child.c
@@ -96,6 +96,39 @@ int lookup_localhost(void)
     return OK;
 }
 
+int
+get_lh_family(void)
+{
+    if (lh.family == AF_UNSPEC)
+        lookup_localhost();
+
+    return lh.family;
+}
+
+const char *
+get_lh_addr(void)
+{
+    if (lh.family == AF_UNSPEC)
+        lookup_localhost();
+
+    return lh.name;
+}
+
+ne_inet_addr *
+get_lh_inet_addr(void)
+{
+    ne_iaddr_type type;
+    unsigned char *raw;
+
+    if (lh.family == AF_UNSPEC)
+        lookup_localhost();
+
+    type = ne_iaddr_ipv4;
+    raw = (unsigned char *) &lh.sockaddr.in.sin_addr.s_addr;
+
+    return ne_iaddr_make(type, raw);
+}
+
 int lookup_hostname(void)
 {
     char buf[BUFSIZ];

--- a/test/common/child.h
+++ b/test/common/child.h
@@ -34,12 +34,6 @@
  * named test. */
 int lookup_localhost(void);
 
-/* Test which looks up real local hostname. */
-int lookup_hostname(void);
-
-/* set to local hostname if lookup_hostname succeeds. */
-extern char *local_hostname;
-
 int get_lh_family(void);
 const char *get_lh_addr(void);
 ne_inet_addr *get_lh_inet_addr(void);
@@ -56,12 +50,6 @@ typedef int (*server_fn)(ne_socket *sock, void *userdata);
  * - the socket is closed when 'fn' returns, so don't close in in 'fn'.
  */
 int spawn_server(int port, server_fn fn, void *userdata);
-
-/* Like spawn_server; if bind_local is non-zero, binds server to
- * localhost, otherwise, binds server to real local hostname.  (must
- * have called lookup_localhost or lookup_hostname as appropriate
- * beforehand).  */
-int spawn_server_addr(int bind_local, int port, server_fn fn, void *userdata);
 
 /* Forks a server child process running 'fn(userdata)' on an
  * unspecified port.  Sets test suite error on failure; on success,

--- a/test/common/child.h
+++ b/test/common/child.h
@@ -40,6 +40,10 @@ int lookup_hostname(void);
 /* set to local hostname if lookup_hostname succeeds. */
 extern char *local_hostname;
 
+int get_lh_family(void);
+const char *get_lh_addr(void);
+ne_inet_addr *get_lh_inet_addr(void);
+
 /* Callback for spawn_server. */
 typedef int (*server_fn)(ne_socket *sock, void *userdata);
 

--- a/test/request.c
+++ b/test/request.c
@@ -2049,17 +2049,19 @@ static int status(void)
 {
     ne_session *sess;
     ne_buffer *buf = ne_buffer_create();
+    const char *lh_addr = get_lh_addr();
     char expect[1024];
 
     ne_snprintf(expect, sizeof expect,
-                "lookup(127.0.0.1)-"
-                "connecting(127.0.0.1,127.0.0.1)-"
-                "connected(127.0.0.1)-"
+                "lookup(%s)-"
+                "connecting(%s,%s)-"
+                "connected(%s)-"
                 "send(0,5000)-"
                 "send(5000,5000)-"
                 "recv(0,5)-"
                 "recv(5,5)-"
-                "disconnected(127.0.0.1)-");
+                "disconnected(%s)-",
+                lh_addr, lh_addr, lh_addr, lh_addr, lh_addr);
 
     CALL(make_session(&sess, single_serve_string, RESP200
                       "Content-Length: 5\r\n\r\n" "abcde"));
@@ -2084,14 +2086,15 @@ static int status_chunked(void)
 {
     ne_session *sess;
     ne_buffer *buf = ne_buffer_create();
+    const char *lh_addr = get_lh_addr();
     char expect[1024];
 
     /* This sequence is not exactly guaranteed by the API, but it's
      * what the current implementation should do. */
     ne_snprintf(expect, sizeof expect,
-                "lookup(127.0.0.1)-"
-                "connecting(127.0.0.1,127.0.0.1)-"
-                "connected(127.0.0.1)-"
+                "lookup(%s)-"
+                "connecting(%s,%s)-"
+                "connected(%s)-"
                 "send(0,5000)-"
                 "send(5000,5000)-"
                 "recv(0,-1)-"
@@ -2100,7 +2103,8 @@ static int status_chunked(void)
                 "recv(3,-1)-"
                 "recv(4,-1)-"
                 "recv(5,-1)-"
-                "disconnected(127.0.0.1)-");
+                "disconnected(%s)-",
+                lh_addr, lh_addr, lh_addr, lh_addr, lh_addr);
 
     CALL(make_session(&sess, single_serve_string, 
                       RESP200 TE_CHUNKED "\r\n" ABCDE_CHUNKS));
@@ -2121,12 +2125,10 @@ static int status_chunked(void)
     return OK;
 }
 
-static const unsigned char raw_127[4] = "\x7f\0\0\01"; /* 127.0.0.1 */
-
 static int local_addr(void)
 {
     ne_session *sess;
-    ne_inet_addr *ia = ne_iaddr_make(ne_iaddr_ipv4, raw_127);
+    ne_inet_addr *ia = get_lh_inet_addr();
 
     CALL(make_session(&sess, single_serve_string, RESP200 
                       "Connection: close\r\n\r\n"));
@@ -2160,7 +2162,7 @@ static int dereg_progress(void)
 static int addrlist(void)
 {
     ne_session *sess;
-    ne_inet_addr *ia = ne_iaddr_make(ne_iaddr_ipv4, raw_127);
+    ne_inet_addr *ia = get_lh_inet_addr();
     const ne_inet_addr *ial[1];
     unsigned int port;
 

--- a/test/socket.c
+++ b/test/socket.c
@@ -452,7 +452,7 @@ static int addr_connect(void)
     ne_inet_addr *ia;
     unsigned int port;
 
-    ia = ne_iaddr_make(ne_iaddr_ipv4, raw_127);
+    ia = get_lh_inet_addr();
     ONN("ne_iaddr_make returned NULL", ia == NULL);
     
     CALL(new_spawn_server(1, serve_close, NULL, &port));
@@ -469,7 +469,7 @@ static int addr_peer(void)
     unsigned int port = 9999, realport;
     int ret;
 
-    ia = ne_iaddr_make(ne_iaddr_ipv4, raw_127);
+    ia = get_lh_inet_addr();
     ONN("ne_iaddr_make returned NULL", ia == NULL);
     
     CALL(new_spawn_server(1, serve_close, NULL, &realport));
@@ -1330,7 +1330,7 @@ static int try_prebind(int addr, int port)
     char buf[128], line[256];
     unsigned int srvport;
 
-    ia = ne_iaddr_make(ne_iaddr_ipv4, raw_127);
+    ia = get_lh_inet_addr();
     ONN("ne_iaddr_make returned NULL", ia == NULL);
     
     CALL(new_spawn_server(1, serve_ppeer, NULL, &srvport));

--- a/test/ssl.c
+++ b/test/ssl.c
@@ -971,7 +971,7 @@ static int fail_missing_CN(void)
 /* test for a bad ipAddress altname */
 static int fail_bad_ipaltname(void)
 {
-    return fail_ssl_request("altname6.cert", CA_CERT, "127.0.0.1",
+    return fail_ssl_request("altname6.cert", CA_CERT, get_lh_addr(),
                             "bad IP altname cert", NE_SSL_IDMISMATCH);
 }
 
@@ -997,7 +997,7 @@ static int fail_wildcard(void)
 
 static int fail_wildcard_ip(void)
 {
-    return fail_ssl_request("wildip.cert", CA_CERT, "127.0.0.1",
+    return fail_ssl_request("wildip.cert", CA_CERT, get_lh_addr(),
                             "wildcard IP", NE_SSL_IDMISMATCH);
 }
 

--- a/test/utils.c
+++ b/test/utils.c
@@ -204,7 +204,8 @@ int multi_session_server(ne_session **sess,
 
 int session_server(ne_session **sess, server_fn fn, void *userdata)
 {
-    return multi_session_server(sess, "http", "127.0.0.1", 1, fn, userdata);
+    return multi_session_server(sess, "http", get_lh_addr(), 1,
+                                fn, userdata);
 }
 
 int proxied_session_server(ne_session **sess, const char *scheme,
@@ -219,7 +220,7 @@ int proxied_session_server(ne_session **sess, const char *scheme,
 
     NE_DEBUG(NE_DBG_HTTP, "test: Using proxied session to port %u.\n", port);
 
-    ne_session_proxy(*sess, "127.0.0.1", port);
+    ne_session_proxy(*sess, get_lh_addr(), port);
 
     return OK;
 }


### PR DESCRIPTION
The test-harness hard-codes references to 127.0.0.1 which prevent it from running successfully on an IPv6-only host:

```
$ sudo ip netns add ipv6test
$ sudo ip netns exec ipv6test ip link set up lo
$ sudo ip netns exec ipv6test ip addr del 127.0.0.1/8 dev lo
$ sudo ip netns exec ipv6test ip addr show lo
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet6 ::1/128 scope host 
       valid_lft forever preferred_lft forever
$ sudo ip netns exec ipv6test sudo -u $USER make -j16 check
[...]
uri-tests............. 15/15 passed                                                      
util-tests............  9/ 9 passed                                                      
string-tests.......... 31/32 SKIPPED - strhash_sha_512_256 (SHA-2-512/256 not supported) 
string-tests.......... 31/32 passed (1 skipped)                                          
socket................  9/47 bind failed: Cannot assign requested address                
socket................  9/47 FAIL - just_connect (could not bind/listen fd for server)   
socket................ 10/47 bind failed: Cannot assign requested address                
socket................ 10/47 FAIL - addr_connect (could not bind/listen fd for server)   
socket................ 11/47 bind failed: Cannot assign requested address                
socket................ 11/47 FAIL - addr_peer (could not bind/listen fd for server)      
socket................ 13/47 bind failed: Cannot assign requested address                
socket................ 13/47 FAIL - read_close (could not bind/listen fd for server)     
socket................ 14/47 bind failed: Cannot assign requested address                
socket................ 14/47 FAIL - peek_close (could not bind/listen fd for server)     
socket................ 16/47 bind failed: Cannot assign requested address                
socket................ 16/47 FAIL - single_read (could not bind/listen fd for server)    
socket................ 17/47 bind failed: Cannot assign requested address                
socket................ 17/47 FAIL - single_peek (could not bind/listen fd for server)    
socket................ 18/47 bind failed: Cannot assign requested address                
socket................ 18/47 FAIL - small_reads (could not bind/listen fd for server)    
socket................ 19/47 bind failed: Cannot assign requested address                
socket................ 19/47 FAIL - read_and_peek (could not bind/listen fd for server)  
socket................ 20/47 bind failed: Cannot assign requested address                
socket................ 20/47 FAIL - larger_read (could not bind/listen fd for server)    
socket................ 21/47 bind failed: Cannot assign requested address                
socket................ 21/47 FAIL - ssl_session_id (could not bind/listen fd for server) 
socket................ 22/47 bind failed: Cannot assign requested address                
socket................ 22/47 FAIL - cipher (could not bind/listen fd for server)         
socket................ 23/47 bind failed: Cannot assign requested address                
socket................ 23/47 FAIL - line_simple (could not bind/listen fd for server)    
socket................ 24/47 bind failed: Cannot assign requested address                
socket................ 24/47 FAIL - line_closure (could not bind/listen fd for server)   
[...]
```

The first three commits in this branch add ipv6 support.  The last one removes `lookup_hostname` and `spawn_server_addr` since these appear to be unused.
