### PR TITLE
test/makekeys.sh: fix POSIX compliance

### DIFF
--- a/test/makekeys.sh
+++ b/test/makekeys.sh
@@ -123,15 +123,15 @@ csr_fields "Self-Signed" | \
 ${MKCERT} -key server.key -out ssigned.pem
 
 # default => T61String
-csr_fields "`echo -e 'H\0350llo World'`" localhost |
+csr_fields "$(printf 'H%bllo World\n' '\0350')" localhost |
 ${REQ} -new -key server.key -out t61subj.csr
 
 STRMASK=pkix # => BMPString
-csr_fields "`echo -e 'H\0350llo World'`" localhost |
+csr_fields "$(printf 'H%bllo World\n' '\0350')" localhost |
 ${REQ} -new -key server.key -out bmpsubj.csr
 
 STRMASK=utf8only # => UTF8String
-csr_fields "`echo -e 'H\0350llo World'`" localhost |
+csr_fields "$(printf 'H%bllo World\n' '\0350')" localhost |
 ${REQ} -new -key server.key -out utf8subj.csr
 
 STRMASK=default


### PR DESCRIPTION
Not all shells provide `echo -e` and using `printf` is more portable.

One shell that will fail is `dash(1)`.

> ssl................... 10/63 FAIL - dname_readable (certificate subject dname was `-e H\0350llo World, Neon Hackers Ltd, Cambridge, Cambridgeshire, GB' not `Hèllo World, Neon Hackers Ltd, Cambridge, Cambridgeshire, GB'

Gentoo-Issue: https://bugs.gentoo.org/832851