### PR TITLE
Remove sprintf() use

### DIFF
--- a/src/ne_207.c
+++ b/src/ne_207.c
@@ -305,11 +305,9 @@ static void handle_error(struct context *ctx, const ne_status *status,
 			 const char *description)
 {
     if (status && status->klass != 2 && status->code != 424) {
-	char buf[50];
 	ctx->is_error = 1;
-	sprintf(buf, "%d", status->code);
-	ne_buffer_concat(ctx->buf, ctx->href, ": ", 
-			 buf, " ", status->reason_phrase, "\n", NULL);
+	ne_buffer_snprintf(ctx->buf, 512, "%s: %d %s\n",
+                           ctx->href, status->code, status->reason_phrase);
 	if (description != NULL) {
 	    /* TODO: these can be multi-line. Would be good to
 	     * word-wrap this at col 80. */

--- a/src/ne_uri.c
+++ b/src/ne_uri.c
@@ -506,7 +506,7 @@ char *ne_path_escapef(const char *path, unsigned int flags)
     for (pnt = (const unsigned char *)path; *pnt != '\0'; pnt++) {
 	if (path_escape_ch(*pnt, mask)) {
 	    /* Escape it - %<hex><hex> */
-	    sprintf(p, "%%%02x", (unsigned char) *pnt);
+	    ne_snprintf(p, 4, "%%%02x", (unsigned char) *pnt);
 	    p += 3;
 	} else {
 	    *p++ = *pnt;


### PR DESCRIPTION
```
* src/ne_207.c (handle_error): Use ne_buffer_snprintf rather than sprintf

* src/ne_uri.c (ne_path_escapef): Use ne_snprintf rather than sprintf.
```