### PR TITLE
Clarify that ne_request_create() takes a target rather than a path.

### DIFF
--- a/src/ne_request.c
+++ b/src/ne_request.c
@@ -506,8 +506,8 @@ int ne_accept_2xx(void *userdata, ne_request *req, const ne_status *st)
     return (st->klass == 2);
 }
 
-ne_request *ne_request_create(ne_session *sess,
-			      const char *method, const char *path) 
+ne_request *ne_request_create(ne_session *sess, const char *method,
+                              const char *target)
 {
     ne_request *req = ne_calloc(sizeof *req);
 
@@ -527,12 +527,12 @@ ne_request *ne_request_create(ne_session *sess,
 
     /* Only use an absoluteURI here when we might be using an HTTP
      * proxy, and SSL is in use: some servers can't parse them. */
-    if (sess->any_proxy_http && !req->session->use_ssl && path[0] == '/')
+    if (sess->any_proxy_http && !req->session->use_ssl && target[0] == '/')
         req->target = ne_concat(req->session->scheme, "://",
                                 req->session->server.hostport,
-                                path, NULL);
+                                target, NULL);
     else
-        req->target = ne_strdup(path);
+        req->target = ne_strdup(target);
 
     {
 	struct hook *hk;

--- a/src/ne_request.h
+++ b/src/ne_request.h
@@ -44,11 +44,12 @@ typedef struct ne_request_s ne_request;
 
 /***** Request Handling *****/
 
-/* Create a request in session 'sess', with given method and path.
- * 'path' must conform to the 'abs_path' grammar in RFC2396, with an
- * optional "? query" part, and MUST be URI-escaped by the caller. */
-ne_request *ne_request_create(ne_session *sess,
-                              const char *method, const char *path)
+/* Create a request in session 'sess', with given method and target.
+ * 'target' is used to form the request-target (per RFC 7230ẞ5.3), and
+ * may be an absolute-path (with optional query-string), an
+ * absolute-URI, or an asterisk. */
+ne_request *ne_request_create(ne_session *sess, const char *method,
+                              const char *target)
     ne_attribute((nonnull));
 
 /* The request body will be taken from 'size' bytes of 'buffer'. */


### PR DESCRIPTION
```
Explicitly allow asterisk-form and absolute-form. (No functional change)

* src/ne_request.c, src/ne_request.h (ne_request_create): Change "path" parameter to "target".

* test/request.c (target_forms): Test that all three target forms generate the expected request-line.
```