### PR TITLE
Retry a request after getting a 408 on a persisted connection.

### DIFF
--- a/test/request.c
+++ b/test/request.c
@@ -1333,12 +1333,13 @@ static int fail_noserver(const char *hostname, unsigned int port, int code)
 {
      ne_session *sess = ne_session_create("http", hostname, port);
      int ret = any_request(sess, "/foo");
+     ne_session_destroy(sess);
 
      ONV(ret == NE_OK,
 	 ("request to server at %s:%u succeeded?!", hostname, port));
      ONV(ret != code, ("request failed with %d not %d", ret, code));
 
-     return destroy_and_wait(sess);
+     return OK;
 }
 
 static int fail_lookup(void)


### PR DESCRIPTION
```
Retry a request after getting a 408 on a persisted connection.

* src/ne_request.c (send_request): Retry for a 408 response.

* test/request.c (retry_408, dont_retry_408): New tests.
```