### PR TITLE
Fix crash in ne_path_escapef

### DIFF
--- a/src/ne_uri.c
+++ b/src/ne_uri.c
@@ -494,7 +494,7 @@ char *ne_path_escapef(const char *path, unsigned int flags)
     if (flags & NE_PATH_NONRES) mask |= URI_ESCAPE;
     if (flags & NE_PATH_NONURI) mask |= URI_NONURI;
 
-    for (pnt = (const unsigned char *)path; *pnt != '\0'; pnt++) {
+    for (pnt = (const unsigned char *)path; pnt && *pnt != '\0'; pnt++) {
         count += path_escape_ch(*pnt, mask);
     }
 


### PR DESCRIPTION
Functions wasn't checking correctly for NULL before accessing path.

Fixes: https://github.com/notroj/neon/issues/134