### PR TITLE
ne_uri_parse fixes

### DIFF
--- a/src/ne_uri.c
+++ b/src/ne_uri.c
@@ -209,19 +209,16 @@ int ne_uri_parse(const char *uri, ne_uri *parsed)
             p++; /* => p = colon */
         } else {
             /* Find the colon. */
-            p = pa;
-            while (*p != ':' && p > s)
-                p--;
+            p = s;
+            while (*p != ':' && p < pa)
+                p++;
         }
+        /* => p = colon */
 
-        if (p == s) {
-            p = pa;
-            /* No colon; => p = path-abempty */
-        } else if (p + 1 != pa) {
-            /* => p = colon */
-            parsed->port = atoi(p + 1);
-        }
         parsed->host = ne_strndup(s, p - s);
+
+        if (p != pa && p + 1 != pa)
+            parsed->port = atoi(p + 1);
         
         s = pa;
     }

--- a/src/ne_uri.c
+++ b/src/ne_uri.c
@@ -181,7 +181,7 @@ int ne_uri_parse(const char *uri, ne_uri *parsed)
 
         s = pa = s + 2; /* => s = authority */
 
-        while (*pa != '/' && *pa != '\0')
+        while (*pa != '/' && *pa != '?' && *pa != '#' && *pa != '\0')
             pa++;
         /* => pa = path-abempty */
         
@@ -223,11 +223,7 @@ int ne_uri_parse(const char *uri, ne_uri *parsed)
         }
         parsed->host = ne_strndup(s, p - s);
         
-        s = pa;        
-
-        if (*s == '\0') {
-            s = "/"; /* FIXME: scheme-specific. */
-        }
+        s = pa;
     }
 
     /* => s = path-abempty / path-absolute / path-rootless
@@ -240,7 +236,10 @@ int ne_uri_parse(const char *uri, ne_uri *parsed)
 
     /* => p = [ "?" query ] [ "#" fragment ] */
 
-    parsed->path = ne_strndup(s, p - s);
+    if (p != s || parsed->host == NULL)
+        parsed->path = ne_strndup(s, p - s);
+    else
+        parsed->path = ne_strdup("/");  /* FIXME: scheme-specific. */
 
     if (*p != '\0') {
         s = p++;

--- a/src/ne_uri.c
+++ b/src/ne_uri.c
@@ -217,8 +217,21 @@ int ne_uri_parse(const char *uri, ne_uri *parsed)
 
         parsed->host = ne_strndup(s, p - s);
 
-        if (p != pa && p + 1 != pa)
-            parsed->port = atoi(p + 1);
+        if (p != pa && p + 1 != pa) {
+            p++;
+
+            s = p;
+            /* => s = port */
+
+            while (p < pa) {
+                if (!(uri_lookup(*p) & URI_DIGIT))
+                    return -1;
+
+                p++;
+            }
+
+            parsed->port = atoi(s);
+        }
         
         s = pa;
     }

--- a/test/uri-tests.c
+++ b/test/uri-tests.c
@@ -296,6 +296,8 @@ static int parse(void)
         { "http://foo/bar#beta", "http", "foo", 0, "/bar", NULL, NULL, "beta" },
         { "http://foo/bar?#beta", "http", "foo", 0, "/bar", NULL, "", "beta" },
         { "http://foo/bar?alpha?beta", "http", "foo", 0, "/bar", NULL, "alpha?beta", NULL },
+        { "http://foo?alpha", "http", "foo", 0, "/", NULL, "alpha", NULL },
+        { "http://foo#beta", "http", "foo", 0, "/", NULL, NULL, "beta" },
 
         /* Examples from RFC3986§1.1.2: */
         { "ftp://ftp.is.co.za/rfc/rfc1808.txt", "ftp", "ftp.is.co.za", 0, "/rfc/rfc1808.txt", NULL, NULL, NULL },

--- a/test/uri-tests.c
+++ b/test/uri-tests.c
@@ -373,12 +373,14 @@ static int parse(void)
 static int failparse(void)
 {
     static const char *uris[] = {
-	"http://[::1/",
-	"http://[::1]f:80/",
-	"http://[::1]]:80/",
+        "http://[::1/",
+        "http://[::1]f:80/",
+        "http://[::1]]:80/",
         "http://foo/bar asda",
         "http://fish/[foo]/bar",
-	NULL
+        "http://foo:80bar",
+        "http://foo:80:80/bar",
+        NULL
     };
     int n;
     


### PR DESCRIPTION
Found a problem that `ne_uri_parse` can't correctly process a uri that has query or fragment, but no path. In this case, query and fragment will be placed in host.
Also found that `ne_uri_parse` accepts an invalid uri that has two or more colons after host or has a port with non-digit characters.