### PR TITLE
Conditionally apply a timeout rather than a maximum count of interim responses

### DIFF
--- a/src/ne_session.c
+++ b/src/ne_session.c
@@ -199,6 +199,7 @@ ne_session *ne_session_create(const char *scheme,
 
     /* Set flags which default to on: */
     sess->flags[NE_SESSFLAG_PERSIST] = 1;
+    sess->flags[NE_SESSFLAG_1XXTIMEOUT] = 1;
 
 #ifdef NE_ENABLE_AUTO_LIBPROXY
     ne_session_system_proxy(sess, 0);

--- a/src/ne_session.h
+++ b/src/ne_session.h
@@ -104,6 +104,10 @@ typedef enum ne_session_flag_e {
                              * to improve interoperability with
                              * SharePoint */
 
+    NE_SESSFLAG_1XXTIMEOUT, /* disable this flag to apply no overall
+                             * timeout when reading interim
+                             * responses. */
+
     NE_SESSFLAG_LAST /* enum sentinel value */
 } ne_session_flag;
 

--- a/test/request.c
+++ b/test/request.c
@@ -2274,7 +2274,7 @@ static int safe_flags(void)
 /* Hit the timeout (2 seconds) for reading interim responses. */
 static int fail_excess_1xx(void)
 {
-    struct s1xx_args args = {2000000, 0};
+    struct s1xx_args args = {20000000, 0};
     return fail_request_with_error(0, serve_1xx, &args, 0,
                                    "Timed out reading interim responses");
 }


### PR DESCRIPTION
```
Rather than appling a maximum count, apply an overall timeout to
reading interim responses to match the read timeout, if a read timeout is configured and the NE_SESSFLAG_1XXTIMEOUT flag is set - which defaults to set (issue #94):

* src/ne_session.h (NE_SESSFLAG_1XXTIMEOUT): New flag.

* src/ne_session.c (ne_session_create): Set NE_SESSFLAG_1XXTIMEOUT to default on.

* src/ne_request.c (send_request): Use the session read timeout to avoid looping reading interim responses indefinitely, rather than hard-coding a maximum number of responses.

* test/request.c (fail_request_with_error): Set read timeout. (fail_excess_1xx): Adjust expected error, send more interim responses.
```