### PR TITLE
Make 1XXTIMEOUT a request flag rather than a session flag:

### DIFF
--- a/doc/ref/reqflags.xml
+++ b/doc/ref/reqflags.xml
@@ -65,6 +65,13 @@
 	      <literal>POST</literal></simpara>
 	    </listitem>
 	  </varlistentry>
+	  <varlistentry>
+            <term><constant>NE_REQFLAG_1XXTIMEOUT</constant> (default on)</term>
+	    <listitem>
+	      <simpara>disable this flag to disable overall timeout
+	      when reading interim (1xx) responses; </simpara>
+	    </listitem>
+	  </varlistentry>
         </variablelist>
   </refsect1>
 

--- a/doc/ref/sessflags.xml
+++ b/doc/ref/sessflags.xml
@@ -105,13 +105,6 @@
 	      improve interoperability with SharePoint</simpara>
 	    </listitem>
 	  </varlistentry>
-	  <varlistentry>
-            <term><constant>NE_SESSFLAG_1XXTIMEOUT</constant> (default on)</term>
-	    <listitem>
-	      <simpara>disable this flag to disable overall timeout
-	      when reading interim (1xx) responses; </simpara>
-	    </listitem>
-	  </varlistentry>
         </variablelist>
   </refsect1>
 

--- a/src/ne_request.h
+++ b/src/ne_request.h
@@ -230,6 +230,10 @@ typedef enum ne_request_flag_e {
     NE_REQFLAG_IDEMPOTENT, /* disable this flag if the request uses a
                             * non-idempotent method such as POST. */
 
+    NE_REQFLAG_1XXTIMEOUT, /* disable this flag to apply no overall
+                             * timeout when reading interim
+                             * responses. */
+
     NE_REQFLAG_LAST /* enum sentinel value */
 } ne_request_flag;
 

--- a/src/ne_session.c
+++ b/src/ne_session.c
@@ -212,7 +212,6 @@ ne_session *ne_session_create(const char *scheme,
 
     /* Set flags which default to on: */
     sess->flags[NE_SESSFLAG_PERSIST] = 1;
-    sess->flags[NE_SESSFLAG_1XXTIMEOUT] = 1;
 
 #ifdef NE_ENABLE_AUTO_LIBPROXY
     ne_session_system_proxy(sess, 0);

--- a/src/ne_session.h
+++ b/src/ne_session.h
@@ -107,10 +107,6 @@ typedef enum ne_session_flag_e {
                              * to improve interoperability with
                              * SharePoint */
 
-    NE_SESSFLAG_1XXTIMEOUT, /* disable this flag to apply no overall
-                             * timeout when reading interim
-                             * responses. */
-
     NE_SESSFLAG_LAST /* enum sentinel value */
 } ne_session_flag;
 


### PR DESCRIPTION
```
* src/ne_request.c (ne_request_create): Set flag here.
  (send_request): Adjust for flag move.

* src/ne_request.h, src/ne_session.h: Move flag from NE_SESSFLAG_1XXTIMEOUT to NE_REQFLAG_1XXTIMEOUT.
```