### PR TITLE
Add CI to generate Docs (#21)

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,0 +1,26 @@
+name: Generate Docs
+
+on:
+  push:
+    branches:
+      - master
+jobs:
+  doc:
+    runs-on: ubuntu-latest
+    steps:
+      - run: sudo apt-get update && sudo apt-get install build-essential autoconf automake libxml2-dev xmlto git
+      - uses: actions/checkout@v2
+
+      - run: ./autogen.sh
+
+      - run: mkdir -p ${GITHUB_WORKSPACE}/prefix && ./configure --prefix=${GITHUB_WORKSPACE}/prefix
+
+      - run: make docs
+
+      - name: Publish generated content to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@4.1.4
+        with:
+          branch: gh-pages
+          folder: doc/html
+          git-config-user: "gh-runner"
+          git-config-email: "gh@example.com"


### PR DESCRIPTION
Hello,

I was just investigating this library for a potential side project and saw the missing docs. I have added a workflow to generate the `doc/html` pages. Please let me know if any stylistic etc changes are desired.

I however could not figure out which branch the github pages for this repo is based off of, so the workflow currently just dumps everything in the `gh-pages` branch. You can see an example at https://sohamg.xyz/neon/ 

Thanks