### PR TITLE
Move Location: handling into ne_request, mostly obsoleting the ne_redirect API

### DIFF
--- a/src/ne_redirect.c
+++ b/src/ne_redirect.c
@@ -1,6 +1,6 @@
 /* 
    HTTP-redirect support
-   Copyright (C) 1999-2021, Joe Orton <joe@manyfish.co.uk>
+   Copyright (C) 1999-2024, Joe Orton <joe@manyfish.co.uk>
 
    This library is free software; you can redistribute it and/or
    modify it under the terms of the GNU Library General Public
@@ -39,80 +39,38 @@
 #define REDIRECT_ID "http://www.webdav.org/neon/hooks/http-redirect"
 
 struct redirect {
-    char *requri;
-    int valid; /* non-zero if .uri contains a redirect */
-    ne_uri uri;
-    ne_session *sess;
+    ne_uri *uri;
 };
 
-static void
-create(ne_request *req, void *session, const char *method, const char *uri)
+#define uri_free_clear(r_) do { if ((r_)->uri) { ne_uri_free((r_)->uri); ne_free((r_)->uri); (r_)->uri = NULL; }} while (0)
+
+static void create(ne_request *req, void *userdata,
+                   const char *method, const char *target)
 {
-    struct redirect *red = session;
-    if (red->requri) ne_free(red->requri);
-    red->requri = ne_strdup(uri);
+    struct redirect *red = userdata;
+
+    uri_free_clear(red);
 }
 
-#define REDIR(n) ((n) == 301 || (n) == 302 || (n) == 303 || \
-		  (n) == 307)
-
-static int post_send(ne_request *req, void *private, const ne_status *status)
+static int post_send(ne_request *req, void *userdata, const ne_status *status)
 {
-    struct redirect *red = private;
-    const char *location = ne_get_response_header(req, "Location");
-    ne_buffer *path = NULL;
-    int ret;
+    struct redirect *red = userdata;
+    ne_uri *loc = ne_get_response_location(req, NULL);
 
-    /* Don't do anything for non-redirect status or no Location header. */
-    if (!REDIR(status->code) || location == NULL)
-	return NE_OK;
+    uri_free_clear(red);
 
-    if (strstr(location, "://") == NULL && location[0] != '/') {
-	char *pnt;
-
-	path = ne_buffer_create();
-	ne_buffer_zappend(path, red->requri);
-	pnt = strrchr(path->data, '/');
-
-	if (pnt && pnt[1] != '\0') {
-	    /* Chop off last path segment. */
-	    pnt[1] = '\0';
-	    ne_buffer_altered(path);
-	}
-	ne_buffer_zappend(path, location);
-	location = path->data;
+    if (status->klass != 3 || loc == NULL) {
+        return NE_OK;
     }
 
-    /* free last uri. */
-    ne_uri_free(&red->uri);
-    
-    /* Parse the Location header */
-    if (ne_uri_parse(location, &red->uri) || red->uri.path == NULL) {
-        red->valid = 0;
-	ne_set_error(red->sess, _("Could not parse redirect destination URL"));
-        ret = NE_ERROR;
-    } else {
-        /* got a valid redirect. */
-        red->valid = 1;
-        ret = NE_REDIRECT;
-
-        if (!red->uri.host) {
-            /* Not an absoluteURI: breaks 2616 but everybody does it. */
-            ne_fill_server_uri(red->sess, &red->uri);
-        }
-    }
-
-    if (path) ne_buffer_destroy(path);
-
-    return ret;
+    red->uri = loc;
+    return NE_REDIRECT;
 }
 
 static void free_redirect(void *cookie)
 {
     struct redirect *red = cookie;
-    ne_uri_free(&red->uri);
-    if (red->requri)
-        ne_free(red->requri);
+    uri_free_clear(red);
     ne_free(red);
 }
 
@@ -120,8 +78,6 @@ void ne_redirect_register(ne_session *sess)
 {
     struct redirect *red = ne_calloc(sizeof *red);
     
-    red->sess = sess;
-
     ne_hook_create_request(sess, create, red);
     ne_hook_post_send(sess, post_send, red);
     ne_hook_destroy_session(sess, free_redirect, red);
@@ -133,9 +89,6 @@ const ne_uri *ne_redirect_location(ne_session *sess)
 {
     struct redirect *red = ne_get_session_private(sess, REDIRECT_ID);
 
-    if (red && red->valid)
-        return &red->uri;
-    else
-        return NULL;
+    return red ? red->uri : NULL;
 }
 

--- a/src/ne_request.h
+++ b/src/ne_request.h
@@ -1,6 +1,6 @@
 /* 
    HTTP Request Handling
-   Copyright (C) 1999-2021, Joe Orton <joe@manyfish.co.uk>
+   Copyright (C) 1999-2024, Joe Orton <joe@manyfish.co.uk>
 
    This library is free software; you can redistribute it and/or
    modify it under the terms of the GNU Library General Public
@@ -165,6 +165,15 @@ void ne_add_request_header(ne_request *req, const char *name,
 void ne_print_request_header(ne_request *req, const char *name,
 			     const char *format, ...) 
     ne_attribute((format(printf, 3, 4)));
+
+/* If the response includes a Location header, this function parses
+ * and resolves the URI-references relative to the request target URI.
+ * If a fragment ("#fragment") is used for the request target, it can
+ * be passed as an argument to allow relative resolution. Returns a
+ * malloc-allocated ne_uri object, or NULL if the URI in the Location
+ * header could not be parsed, or the Location header was not
+ * present. */
+ne_uri *ne_get_response_location(ne_request *req, const char *fragment);
 
 /* ne_request_dispatch: Sends the given request, and reads the
  * response.  Returns:


### PR DESCRIPTION
```
Add ne_get_response_location(). Set descriptive errors for 3xx responses with a Location header.

* src/ne_request.c (ne_get_response_location): New function.
  (ne_end_request): Set descriptive error for a redirect.

* src/ne_redirect.c (create, post_send, free_redirect, ne_redirect_register): Rewritten as a simple cache of the URI returned by ne_get_response_location. Handle any 3xx response.

* src/ne_redirect.h: Note API is deprecated.

* src/ne_request.h: Describe ne_get_response_location.

* test/request.c (redirect_error): New test.

* test/redirect.c (serve_redir): Removed. (check_redir, redirects): Simplify, and enhance to test ne_get_response_location() directly. Add more relative URI checks and fragment handling.
```