### PR TITLE
Define AC_CONFIG_MACRO_DIR

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -11,6 +11,7 @@ This configure script may be copied, distributed and modified under the
 terms of the GNU Library General Public license; see src/COPYING.LIB for
 more details.])
 
+AC_CONFIG_MACRO_DIR([macros])
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_SRCDIR(src/ne_request.c)
 


### PR DESCRIPTION
This is needed for the autoreconf command to detect the location of additional local Autoconf macros.