### PR TITLE
update exported/imported feature flags

### DIFF
--- a/macros/neon.m4
+++ b/macros/neon.m4
@@ -258,6 +258,10 @@ NEON_CHECK_VERSION([
     NE_DEFINE_VERSIONS
     neon_library_message="library in ${neon_prefix} (${NEON_VERSION})"
     neon_xml_parser_message="using whatever neon uses"
+    NEON_CHECK_SUPPORT([i18n], [I18N], [Internationalization])
+    NEON_CHECK_SUPPORT([dav], [DAV], [WebDAV])
+    NEON_CHECK_SUPPORT([gssapi], [GSSAPI], [GSSAPI])
+    NEON_CHECK_SUPPORT([libpxy], [LIBPXY], [libproxy])
     NEON_CHECK_SUPPORT([ssl], [SSL], [SSL])
     NEON_CHECK_SUPPORT([zlib], [ZLIB], [zlib])
     NEON_CHECK_SUPPORT([ipv6], [IPV6], [IPv6])

--- a/neon-config.in
+++ b/neon-config.in
@@ -24,7 +24,7 @@ Known values for OPTION are:
 
  Known features: 
     dav [@NE_FLAG_DAV@], ssl [@NE_FLAG_SSL@], zlib [@NE_FLAG_ZLIB@], ipv6 [@NE_FLAG_IPV6@], lfs [@NE_FLAG_LFS@],
-    i18n [@NE_FLAG_I18N@], ts_ssl [@NE_FLAG_TS_SSL@]
+    i18n [@NE_FLAG_I18N@], ts_ssl [@NE_FLAG_TS_SSL@], gssapi [@NE_FLAG_GSSAPI@], libpxy [@NE_FLAG_LIBPXY@]
 
 EOF
 
@@ -89,6 +89,8 @@ while test $# -gt 0; do
 	shift
 
 	case "$1" in
+	gssapi|GSSAPI) support @NE_FLAG_GSSAPI@ ;;
+	libpxy|LIBPXY) support @NE_FLAG_LIBPXY@ ;;
 	ssl|SSL) support @NE_FLAG_SSL@ ;;
 	zlib|ZLIB) support @NE_FLAG_ZLIB@ ;;
 	ipv6|IPV6) support @NE_FLAG_IPV6@ ;;


### PR DESCRIPTION
``
* macros/neon.m4 (NEON_USE_EXTERNAL): Update to collect all exported
  feature flags.

* neon-config.in: Support gssapi, libpxy feature flags.
``