### PR TITLE
Update version handling.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 
-[![Travis CI Build Status](https://travis-ci.com/notroj/neon.svg?branch=master)](https://travis-ci.com/github/notroj/neon)
 [![Build and test](https://github.com/notroj/neon/actions/workflows/ci.yml/badge.svg)](https://github.com/notroj/neon/actions/workflows/ci.yml)
 
 # neon
@@ -9,7 +8,8 @@ _neon_ is an HTTP and WebDAV client library, with a C language API.
 GitHub: https://github.com/notroj/neon | Web: https://notroj.github.io/neon/
 
 The neon API and ABI are stable and maintain backwards compatibility
-since 0.27 through to current releases.
+since 0.27 through to 1.0.0. From neon 1.0.0 onwards, semantic
+versioning will be used. https://semver.org/
 
 Features:
 
@@ -43,7 +43,7 @@ The autoconf macros in the "macros" directory are under a less
 restrictive license, see each file for details.
 
 ~~~
-neon is Copyright (C) 1999-2023 Joe Orton
+neon is Copyright (C) 1999-2024 Joe Orton
 Portions are:
 Copyright (C) Aleix Conchillo Flaque
 Copyright (C) Arfrever Frehtes Taifersar Arahesis

--- a/test/util-tests.c
+++ b/test/util-tests.c
@@ -288,18 +288,22 @@ static int versioning(void)
     GOOD(NE_VERSION_MAJOR, NE_VERSION_MINOR, "current version");
     BAD(NE_VERSION_MAJOR + 1, 0, "later major");
     BAD(NE_VERSION_MAJOR, NE_VERSION_MINOR + 1, "later minor");
-#if NE_VERSION_MAJOR > 0
+
+#if NE_VERSION_MAJOR > 1
     BAD(NE_VERSION_MAJOR - 1, 0, "earlier major");
 #if NE_VERSION_MINOR > 0
     GOOD(NE_VERSION_MAJOR, NE_VERSION_MINOR - 1, "earlier minor");
 #endif /* NE_VERSION_MINOR > 0 */
-#else /* where NE_VERSION_MAJOR == 0 */
-    BAD(0, 26, "earlier minor for 0.x");
+
+#else /* where NE_VERSION_MAJOR < 2; note that 0.28 thru 1.0 maintain
+       * backwards compatibility to 0.27 */
+    BAD(0, 26, "minor version before 0.27");
     GOOD(0, 27, "current version back-compat to 0.27");
     GOOD(0, 28, "current version back-compat to 0.28");
     GOOD(0, 29, "current version back-compat to 0.29");
     GOOD(0, 30, "current version back-compat to 0.30");
 #endif
+
     return OK;
 }
 


### PR DESCRIPTION
```
* macros/neon.m4 (NE_MINIMUM_VERSION): New macro. (NE_REQUIRE_VERSIONS): Rejig to use NE_MINIMUM_VERSION. The first version given in minor releases is used as the minimum, all others now ignored.

* test/util-tests.c (versioning): Update versioning to assume 1.0 is maintains backwards-compat to 0.27.

* README.md: Note use of semver.
```