### PR TITLE
Fix leak in redirect API

### DIFF
--- a/src/ne_redirect.c
+++ b/src/ne_redirect.c
@@ -55,16 +55,17 @@ static void create(ne_request *req, void *userdata,
 static int post_send(ne_request *req, void *userdata, const ne_status *status)
 {
     struct redirect *red = userdata;
-    ne_uri *loc = ne_get_response_location(req, NULL);
+    ne_uri *loc;
 
     uri_free_clear(red);
 
-    if (status->klass != 3 || loc == NULL) {
-        return NE_OK;
+    if (status->klass == 3
+        && (loc = ne_get_response_location(req, NULL)) != NULL) {
+        red->uri = loc;
+        return NE_REDIRECT;
     }
 
-    red->uri = loc;
-    return NE_REDIRECT;
+    return NE_OK;
 }
 
 static void free_redirect(void *cookie)


### PR DESCRIPTION
```
* src/ne_redirect.c (post_send): Rejig logic to fix a memory leak for
  a 2xx response with a Location header introduced in commit 2931acdb.
```