### PR TITLE
Drop special handling of 3xx responses

### DIFF
--- a/src/ne_request.c
+++ b/src/ne_request.c
@@ -1633,15 +1633,6 @@ int ne_end_request(ne_request *req)
 	ret = fn(req, hk->userdata, &req->status);
     }
 
-    if (ret == NE_OK && req->status.klass == 3) {
-        const char *dest;
-
-        dest = get_response_header_hv(req, HH_HV_LOCATION, "location");
-        if (dest) {
-            ne_set_error(req->session, _("Redirected to %s"), dest);
-        }
-    }
-
     /* Close the connection if persistent connections are disabled or
      * not supported by the server. */
     if (!req->session->flags[NE_SESSFLAG_PERSIST] || !req->can_persist)

--- a/test/request.c
+++ b/test/request.c
@@ -222,6 +222,10 @@ static int reason_phrase(void)
     return OK;    
 }
 
+#if 0
+/* This feature was added then remoevd, it potentially wasn't safe
+ * since the location string wasn't cleaned or checked to be a valid
+ * URI. */
 static int redirect_error(void)
 {
     ne_session *sess;
@@ -241,6 +245,7 @@ static int redirect_error(void)
     ne_session_destroy(sess);
     return OK;
 }
+#endif
 
 static int no_body_304(void)
 {
@@ -2554,7 +2559,9 @@ ne_test tests[] = {
     T(retry_408),
     T(dont_retry_408),
     T(ipv6_literal),
+#if 0
     T(redirect_error),
+#endif
     T(targets),
     T(NULL)
 };


### PR DESCRIPTION
```
* src/ne_request.c (ne_end_request): Drop special handling for 3xx
  responses since the location wasn't cleaned.

* test/request.c (redirect_error): Disable test.
```