### PR TITLE
Add wrapper for strtoul(,,16) for safely parsing hex strings

### DIFF
--- a/src/ne_auth.c
+++ b/src/ne_auth.c
@@ -1305,10 +1305,9 @@ static int verify_digest_response(struct auth_request *req, auth_session *sess,
                                    "client nonce mismatch"));
     }
     else if (nc) {
-        char *ptr;
+        const char *ptr;
         
-        errno = 0;
-        nonce_count = strtoul(nc, &ptr, 16);
+        nonce_count = ne_strhextoul(nc, &ptr);
         if (*ptr != '\0' || errno) {
             ret = NE_ERROR;
             ne_set_error(sess->sess, _("Digest mutual authentication failure: "

--- a/src/ne_request.c
+++ b/src/ne_request.c
@@ -935,6 +935,7 @@ static int read_response_block(ne_request *req, struct ne_response *resp,
          * number of bytes left to read in the current chunk. */
 	if (resp->body.chunk.remain == 0) {
             unsigned long chunk_len;
+            const char *cptr;
             char *ptr;
 
             /* Read chunk-size. */
@@ -956,19 +957,11 @@ static int read_response_block(ne_request *req, struct ne_response *resp,
                 *ptr = '\0';
             }
 
-            /* Reject things strtoul would otherwise allow */
-            ptr = req->respbuf;
-            if (*ptr == '\0' || *ptr == '-' || *ptr == '+'
-                || (ptr[0] == '0' && ptr[1] == 'x')) {
-                return aborted(req, _("Could not parse chunk size"), 0);
-            }
-
-            /* Limit chunk size to <= UINT_MAX, for sanity; must have
-             * a following NUL due to chunk-ext handling above. */
-            errno = 0;
-            chunk_len = strtoul(req->respbuf, &ptr, 16);
-            if (errno || ptr == req->respbuf || (*ptr != '\0' && *ptr != '\r')
-                || chunk_len == ULONG_MAX || chunk_len > UINT_MAX) {
+           /* Limit chunk size to <= UINT_MAX, for sanity; must have
+            * a following NUL due to chunk-ext handling above. */
+            chunk_len = ne_strhextoul(req->respbuf, &cptr);
+            if (errno || (*cptr != '\0' && *cptr != '\r')
+                || chunk_len > UINT_MAX) {
                 return aborted(req, _("Could not parse chunk size"), 0);
             }
             NE_DEBUG(NE_DBG_HTTP, "req: Chunk size: %lu\n", chunk_len);

--- a/src/ne_string.c
+++ b/src/ne_string.c
@@ -36,6 +36,7 @@
 
 #include <stdio.h>
 #include <assert.h>
+#include <errno.h>
 
 #include "ne_alloc.h"
 #include "ne_string.h"
@@ -800,4 +801,26 @@ char *ne_strparam(const char *charset, const char *lang,
     *rp = '\0';
 
     return rv;
+}
+
+unsigned long ne_strhextoul(const char *str, const char **end)
+{
+    unsigned long ret;
+    char *p;
+
+    if ((str[0] == '0' && (str[1] == 'x' || str[1] == 'X'))
+        || !((str[0] >= '0' && str[0] <= '9')
+             || (str[0] >= 'A' && str[0] <= 'Z')
+             || (str[0] >= 'a' && str[0] <= 'z'))) {
+        errno = EINVAL;
+        p = (char *)str;
+        ret = ULONG_MAX;
+    }
+    else {
+        errno = 0;
+        ret = strtoul(str, &p, 16);
+    }
+    if (end) *end = (const char *)p;
+
+    return ret;
 }

--- a/src/ne_string.h
+++ b/src/ne_string.h
@@ -220,6 +220,13 @@ char *ne_strparam(const char *charset, const char *lang,
                   const unsigned char *value)
     ne_attribute((nonnull (1, 3))) ne_attribute_malloc;
 
+/* Parse a hex string like strtoul(,,16), but:
+ * a) any whitespace, 0x or -/+ prefixes result in EINVAL
+ * b) errno is always set (to zero or an error)
+ * c) end pointer is const char *
+ */
+unsigned long ne_strhextoul(const char *str, const char **endptr);
+
 NE_END_DECLS
 
 #endif /* NE_STRING_H */

--- a/src/neon.vers
+++ b/src/neon.vers
@@ -51,3 +51,6 @@ NEON_0_34 {
     ne_sock_getproto;
 };
 
+NEON_0_35 {
+    ne_strhextoul;
+};

--- a/test/request.c
+++ b/test/request.c
@@ -1491,6 +1491,8 @@ static int fail_on_invalid(void)
           "Could not parse chunk size" },
         { RESP200 TE_CHUNKED "\r\n" "0x5\r\n" VALID_ABCDE,
           "Could not parse chunk size" },
+        { RESP200 TE_CHUNKED "\r\n" "0X5\r\n" VALID_ABCDE,
+          "Could not parse chunk size" },
         { RESP200 TE_CHUNKED "\r\n" "+5\r\n" VALID_ABCDE,
           "Could not parse chunk size" },
         { RESP200 TE_CHUNKED "\r\n" "5 5\r\n" VALID_ABCDE,


### PR DESCRIPTION
```
    Add wrapper for strtoul(,,16) for safely parsing hex strings:
    
    * src/ne_string.c (ne_strhextoul): New function.
    
    * test/string-tests.c (strhextoul): Add test case.
    
    * src/ne_request.c (read_response_block): Use ne_strhextoul()
      rather than strtoul.
    
    * src/ne_auth.c (verify_digest_response): Likewise.
    
    * src/neon.vers, src/ne_string.h: Add new API.

```