### PR TITLE
Fix ne_move() for 0-depth locked source parent collection

### DIFF
--- a/src/ne_basic.c
+++ b/src/ne_basic.c
@@ -443,7 +443,11 @@ static int copy_or_move(ne_session *sess, int is_move, int overwrite,
 
 #ifdef NE_HAVE_DAV
     if (is_move) {
-	ne_lock_using_resource(req, src, NE_DEPTH_INFINITE);
+        /* Moving the resource requires any locks for the source
+         * resource (which may be a collection), and modifies the
+         * parent of the source. */
+        ne_lock_using_resource(req, src, NE_DEPTH_INFINITE);
+        ne_lock_using_parent(req, src);
     }
     ne_lock_using_resource(req, dest, NE_DEPTH_INFINITE);
     /* And we need to be able to add members to the destination's parent */


### PR DESCRIPTION
```
Fix ne_move() to submit lock tokens for the parent collection of the
source resource if it is locked with depth 0.

* src/ne_basic.c (copy_or_move): Call ne_lock_using_parent() for the source resource for the MOVE case.
```