### PR TITLE
Fix regression in parsing <status> in 207 responses with an omitted reason-phrase

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
     - run: make -j`nproc`
     - run: make check
     - if: failure()
-      run: if test -f test/debug.log; then tail -n50 test/debug.log; fi
+      run: if test -f test/debug.log; then cat test/debug.log; fi
 
   containers:
     runs-on: ubuntu-latest

--- a/test/props.c
+++ b/test/props.c
@@ -370,11 +370,12 @@ static int propfind(void)
         { "DAV:", "fishbone", },
         { NULL, NULL }
     };
-    size_t n;
+    unsigned n;
 
     for (n = 0; n < sizeof(ts)/sizeof(ts[0]); n++) {
         const ne_propname *pset = pset1;
 
+        NE_DEBUG(NE_DBG_HTTP, "--> running test %u for %s\n", n, ts[n].resp);
         CALL(run_propfind(pset, ts[n].resp, ts[n].depth,
                           ts[n].expected, ts[n].type));
     }

--- a/test/twooh7.c
+++ b/test/twooh7.c
@@ -365,8 +365,22 @@ static int two_oh_seven(void)
           "end-prop[propone];"
           "start-prop[/alpha,/alpha-1,proptwo];cdata-prop[foobar];"
           "end-prop[proptwo];"
-          "end-pstat[/alpha-1]-status={200 OK};end-resp[/alpha];" }
+          "end-pstat[/alpha-1]-status={200 OK};end-resp[/alpha];" },
 
+        /* test for whitespace around href, which should be
+         * ignored. */
+        { MULTI_207(RESP_207(" /spaces ", STAT_207("200 OK") DESCR_207(""))),
+          "start-resp[/spaces];end-resp[/spaces]-status={200 OK};" },
+
+        /* test for whitespace around href, which should be
+         * ignored. */
+        { MULTI_207(RESP_207(" /spaces ", STAT_207("200 OK\n") DESCR_207(""))),
+          "start-resp[/spaces];end-resp[/spaces]-status={200 OK};" },
+
+        /* test for omitted reason-phrase in status-line, which is
+         * valid, per https://github.com/notroj/neon/issues/188 */
+        { MULTI_207(RESP_207("/bar", STAT_207("200 ") DESCR_207(""))),
+          "start-resp[/bar];end-resp[/bar]-status={200 };" }
     };
     unsigned n;
 


### PR DESCRIPTION
```
Fix regression in parsing <status> in 207 responses with an omitted reason-phrase (empty) reason-phrase (fixes #188).

* src/ne_207.c (cdata_207): Strip leading whitespace here. (end_element): Only shave whitespace for <href>; for <status> trim trailing whitespace in the reason phrase only after parsing the status-line.

* test/twooh7.c (two_oh_seven): Add tests for whitespace handling.

* test/props.c (propfind): Better debugging output.
```