### PR TITLE
Fix a crash in NTLM auth path

### DIFF
--- a/src/ne_auth.c
+++ b/src/ne_auth.c
@@ -400,9 +400,9 @@ static char *get_cnonce(const struct hashalg *alg, ne_buffer **errmsg)
 static int get_credentials(auth_session *sess, ne_buffer **errmsg, int attempt,
                            struct auth_challenge *chall, char *pwbuf)
 {
+    char *realm = sess->realm ? ne_strclean(ne_strdup(sess->realm)) : "";
     unsigned mask = chall->protocol->id | sess->spec->protomask;
     int rv;
-    char *realm = ne_strclean(ne_strdup(sess->realm));
 
     if (chall->handler->new_creds)
         rv = chall->handler->new_creds(chall->handler->userdata,
@@ -413,7 +413,7 @@ static int get_credentials(auth_session *sess, ne_buffer **errmsg, int attempt,
         rv = chall->handler->old_creds(chall->handler->userdata, realm,
                                        chall->handler->attempt++, sess->username, pwbuf);
 
-    ne_free(realm);
+    if (sess->realm) ne_free(realm);
 
     if (rv == 0)
         return 0;


### PR DESCRIPTION
```
* src/ne_auth.c (get_credentials): Fix #190, a crash in NTLM auth
  after 0007f22 since sess->realm can be NULL. Always pass a non-NULL
  string to the creds callback.
```