### PR TITLE
Allow definition of NEON_TEST_INIT for test framework initialization

### DIFF
--- a/test/common/tests.c
+++ b/test/common/tests.c
@@ -251,6 +251,13 @@ int main(int argc, char *argv[])
 	printf(" Socket library initialization failed.\n");
     }
 
+#ifdef NEON_TEST_INIT
+    if (NEON_TEST_INIT(test_argc, (const char *const *)test_argv, &use_colour, &quiet)) {
+	fprintf(stderr, "%s: Failed parsing command-line.\n", test_suite);
+        return -1;
+    }
+#endif
+
     if ((tmp = getenv("TEST_QUIET")) != NULL && strcmp(tmp, "1") == 0) {
         quiet = 1;
     }

--- a/test/common/tests.h
+++ b/test/common/tests.h
@@ -64,6 +64,14 @@ extern ne_test tests[];
 /* define a test function which is expected to fail memory leak checks */
 #define T_XLEAKY(fn) { fn, #fn, T_EXPECT_LEAKS }
 
+#ifdef NEON_TEST_INIT
+/* If the NEON_TEST_INIT macro is defined, it defines a function which
+ * will be called to parse the argv array, and can optionally disable
+ * use of colour or enable quiet output.  The main() function will
+ * bail out if the function returns non-zero. */
+int NEON_TEST_INIT(int argc, const char *const *argv, int *use_colour, int *quiet);
+#endif
+
 /* current test number */
 extern int test_num;
 


### PR DESCRIPTION
```
Allow definition of NEON_TEST_INIT for test framework initialization and argv option parsing.

* test/common/tests.h: Conditionally declare NEON_TEST_INIT function.

* test/common/tests.c (main): If NEON_TEST_INIT is defined, call and allow override of colour and quiet mode.
```